### PR TITLE
Add snapshot support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ### Improvements & Bugfixes
 
+- Add snapshot support! The dry runner can now correctly predict the schema of your snapshots and if they will 
+  run or not. It can catch configuration errors as well such as incorrect `unique_key`, `check_cols` and
+  `updated_at` columns
+
 - Added support for `as_number` filter in `profiles.yml`
 
 - Support both `schema` and `dataset` in `profiles.yml` as in BigQuery they are used interchangeably

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ your knowledge
 6. Permission errors: The dry runner should run under the same service account your production 
 job runs under. This allows you to catch problems with table/project permissions as dry run queries
 need table read permissions just like the real query
+7. Incorrect configuration of snapshots: For example a typo in the `unique_key` config. Or `check_cols` which do not 
+exist in the snapshot
    
 ### Things this can't catch
 
@@ -170,8 +172,6 @@ service account JSON files then this won't be able to read `profiles.yml` correc
 The implementation of seeds is incomplete as well as we don't use them very much in our 
 own dbt projects. The dry runner will just use the datatypes that `agate` infers from the CSV 
 files.
-
-Snapshots are also not yet supported.
 
 [dbt-home]: https://www.getdbt.com/
 [bq-dry-run]: https://cloud.google.com/bigquery/docs/dry-run-queries

--- a/README.md
+++ b/README.md
@@ -31,7 +31,15 @@ Then on the same machine (So that the dry runner has access to your dbt project 
 dbt-dry-run <PROFILE>
 ```
 
-By default, it will search for `profiles.yml` in `~/.dbt/` and use the default target specified.
+Where `PROFILE` should match the profile specified in your `dbt_project.yml`:
+
+```
+# This setting configures which "profile" dbt uses for this project.
+# This will get overridden by the root project
+profile: 'default'
+```
+
+Like dbt it will search for `profiles.yml` in `~/.dbt/` and use the default target specified.
 It will also look for the `manifest.yml` in the current working directory. 
 Just like in the dbt CLI you can override these defaults:
 

--- a/dbt_dry_run/exception.py
+++ b/dbt_dry_run/exception.py
@@ -12,3 +12,7 @@ class NodeExecutionException(Exception):
 
 class SchemaChangeException(Exception):
     pass
+
+
+class SnapshotConfigException(Exception):
+    pass

--- a/dbt_dry_run/execution.py
+++ b/dbt_dry_run/execution.py
@@ -29,9 +29,10 @@ _RUNNERS = get_runner_map(_RUNNER_CLASSES)
 
 def dispatch_node(node: Node, runners: Dict[str, NodeRunner]) -> DryRunResult:
     try:
-        return runners[node.resource_type].run(node)
+        runner = runners[node.resource_type]
     except KeyError:
         raise ValueError(f"Unknown resource type '{node.resource_type}'")
+    return runner.run(node)
 
 
 def dry_run_node(runners: Dict[str, NodeRunner], node: Node, results: Results) -> None:

--- a/dbt_dry_run/execution.py
+++ b/dbt_dry_run/execution.py
@@ -3,6 +3,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple
 
+from dbt_dry_run.node_runner.snapshot_runner import SnapshotRunner
 from dbt_dry_run.sql_runner import SQLRunner
 
 if TYPE_CHECKING:
@@ -13,7 +14,7 @@ else:
 from dbt_dry_run.exception import NodeExecutionException, NotCompiledException
 from dbt_dry_run.models import Output
 from dbt_dry_run.models.manifest import Manifest, Node
-from dbt_dry_run.node_runner import NodeRunner
+from dbt_dry_run.node_runner import NodeRunner, get_runner_map
 from dbt_dry_run.node_runner.model_runner import ModelRunner
 from dbt_dry_run.node_runner.seed_runner import SeedRunner
 from dbt_dry_run.results import DryRunResult, DryRunStatus, Results
@@ -22,8 +23,8 @@ from dbt_dry_run.sql_runner.big_query_sql_runner import BigQuerySQLRunner
 
 CONCURRENCY = 8
 
-_RUNNER_CLASSES: List[Any] = [ModelRunner, SeedRunner]
-_RUNNERS = {runner.resource_type: runner for runner in _RUNNER_CLASSES}
+_RUNNER_CLASSES: List[Any] = [ModelRunner, SeedRunner, SnapshotRunner]
+_RUNNERS = get_runner_map(_RUNNER_CLASSES)
 
 
 def dispatch_node(node: Node, runners: Dict[str, NodeRunner]) -> DryRunResult:

--- a/dbt_dry_run/models/manifest.py
+++ b/dbt_dry_run/models/manifest.py
@@ -1,7 +1,7 @@
 import json
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -23,6 +23,10 @@ class NodeConfig(BaseModel):
     materialized: str
     on_schema_change: Optional[OnSchemaChange]
     sql_header: Optional[str]
+    unique_key: Optional[str]
+    updated_at: Optional[str]
+    strategy: Union[None, Literal["timestamp", "check"]]
+    check_cols: Optional[Union[Literal["all"], List[str]]]
 
 
 class Node(BaseModel):

--- a/dbt_dry_run/models/table.py
+++ b/dbt_dry_run/models/table.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from google.cloud.bigquery import SchemaField
 from google.cloud.bigquery.table import Table as BigQueryTable
@@ -52,6 +52,10 @@ class Table(BaseModel):
         schema = bigquery_table.schema
         new_fields = cls.map_fields(schema)
         return cls(fields=new_fields)
+
+    @property
+    def field_names(self) -> Set[str]:
+        return set(field.name for field in self.fields)
 
     @classmethod
     def map_fields(

--- a/dbt_dry_run/node_runner/__init__.py
+++ b/dbt_dry_run/node_runner/__init__.py
@@ -1,4 +1,6 @@
+import itertools
 from abc import ABCMeta, abstractmethod
+from typing import Dict, List, Tuple, Type
 
 from dbt_dry_run.models.manifest import Node
 from dbt_dry_run.results import DryRunResult, Results
@@ -10,7 +12,7 @@ class NodeRunner(metaclass=ABCMeta):
     Runs a node and returns a result
     """
 
-    resource_type: str
+    resource_type: Tuple[str, ...]
 
     def __init__(self, sql_runner: SQLRunner, results: Results):
         self._sql_runner = sql_runner
@@ -19,3 +21,15 @@ class NodeRunner(metaclass=ABCMeta):
     @abstractmethod
     def run(self, node: Node) -> DryRunResult:
         ...
+
+
+def _get_runner_resource_types(
+    runner: Type[NodeRunner],
+) -> List[Tuple[str, Type[NodeRunner]]]:
+    return [(resource_type, runner) for resource_type in runner.resource_type]
+
+
+def get_runner_map(runners: List[Type[NodeRunner]]) -> Dict[str, Type[NodeRunner]]:
+    return dict(
+        itertools.chain(*[_get_runner_resource_types(runner) for runner in runners])
+    )

--- a/dbt_dry_run/node_runner/seed_runner.py
+++ b/dbt_dry_run/node_runner/seed_runner.py
@@ -11,7 +11,7 @@ from dbt_dry_run.results import DryRunResult, DryRunStatus
 
 
 class SeedRunner(NodeRunner):
-    resource_type = "seed"
+    resource_type = ("seed",)
 
     DEFAULT_TYPE = BigQueryFieldType.STRING
     TYPE_MAP = {

--- a/dbt_dry_run/node_runner/snapshot_runner.py
+++ b/dbt_dry_run/node_runner/snapshot_runner.py
@@ -1,0 +1,70 @@
+from typing import Set
+
+from dbt_dry_run.exception import SnapshotConfigException, UpstreamFailedException
+from dbt_dry_run.literals import insert_dependant_sql_literals
+from dbt_dry_run.models import Table
+from dbt_dry_run.models.manifest import Node
+from dbt_dry_run.node_runner import NodeRunner
+from dbt_dry_run.results import DryRunResult, DryRunStatus
+
+
+def _check_cols_missing(node: Node, table: Table) -> Set[str]:
+    if not node.config.check_cols or node.config.check_cols == "all":
+        return set()
+    return set(filter(lambda col: col not in table.field_names, node.config.check_cols))
+
+
+class SnapshotRunner(NodeRunner):
+    resource_type = ("snapshot",)
+
+    @staticmethod
+    def _validate_snapshot_config(node: Node, result: DryRunResult) -> DryRunResult:
+        if not result.table:
+            raise ValueError("Can't validate result without table")
+        if node.config.unique_key not in result.table.field_names:
+            exception = SnapshotConfigException(
+                f"Missing `unique_key` column '{node.config.unique_key}'"
+            )
+            return DryRunResult(
+                node=result.node,
+                table=result.table,
+                status=DryRunStatus.FAILURE,
+                exception=exception,
+            )
+        if node.config.strategy == "timestamp":
+            if node.config.updated_at not in result.table.field_names:
+                exception = SnapshotConfigException(
+                    f"Missing `updated_at` column '{node.config.updated_at}'"
+                )
+                return DryRunResult(
+                    node=result.node,
+                    table=result.table,
+                    status=DryRunStatus.FAILURE,
+                    exception=exception,
+                )
+        elif node.config.strategy == "check":
+            if _check_cols_missing(node, result.table):
+                exception = SnapshotConfigException(
+                    f"Missing `check_cols` '{node.config.check_cols}'"
+                )
+                return DryRunResult(
+                    node=result.node,
+                    table=result.table,
+                    status=DryRunStatus.FAILURE,
+                    exception=exception,
+                )
+        else:
+            raise ValueError(f"Unknown snapshot strategy: '{node.config.strategy}'")
+        return result
+
+    def run(self, node: Node) -> DryRunResult:
+        try:
+            run_sql = insert_dependant_sql_literals(node, self._results)
+        except UpstreamFailedException as e:
+            return DryRunResult(node, None, DryRunStatus.FAILURE, e)
+
+        status, predicted_table, exception = self._sql_runner.query(run_sql)
+        result = DryRunResult(node, predicted_table, status, exception)
+        if result.status == DryRunStatus.SUCCESS and result.table:
+            result = self._validate_snapshot_config(node, result)
+        return result

--- a/dbt_dry_run/scheduler.py
+++ b/dbt_dry_run/scheduler.py
@@ -9,8 +9,9 @@ from dbt_dry_run.models.manifest import Manifest, Node
 class ManifestScheduler:
     MODEL = "model"
     SEED = "seed"
-    RUNNABLE_RESOURCE_TYPE = (MODEL, SEED)
-    RUNNABLE_MATERIAL = ("view", "table", "incremental", "seed")
+    SNAPSHOT = "snapshot"
+    RUNNABLE_RESOURCE_TYPE = (MODEL, SEED, SNAPSHOT)
+    RUNNABLE_MATERIAL = ("view", "table", "incremental", "seed", "snapshot")
 
     def __init__(self, manifest: Manifest, model: Optional[str] = None):
         self._manifest = manifest

--- a/dbt_dry_run/test/node_runner/test_node_runner.py
+++ b/dbt_dry_run/test/node_runner/test_node_runner.py
@@ -1,0 +1,35 @@
+from typing import cast
+from unittest.mock import MagicMock
+
+from dbt_dry_run.models import Node
+from dbt_dry_run.node_runner import NodeRunner, get_runner_map
+from dbt_dry_run.results import DryRunResult, Results
+from dbt_dry_run.sql_runner.big_query_sql_runner import BigQuerySQLRunner
+
+
+class SingleNodeRunner(NodeRunner):
+    resource_type = ("single",)
+
+    def run(self, node: Node) -> DryRunResult:
+        return cast(DryRunResult, None)
+
+
+class MultiNodeRunner(NodeRunner):
+    resource_type = ("first", "second")
+
+    def run(self, node: Node) -> DryRunResult:
+        return cast(DryRunResult, None)
+
+
+def test_get_runner_map_single_resource_type() -> None:
+    runner_map = get_runner_map([SingleNodeRunner])
+    assert {SingleNodeRunner.resource_type[0]: SingleNodeRunner} == runner_map
+
+
+def test_get_runner_map_multi_resource_type() -> None:
+    runner_map = get_runner_map([SingleNodeRunner, MultiNodeRunner])
+    assert {
+        SingleNodeRunner.resource_type[0]: SingleNodeRunner,
+        MultiNodeRunner.resource_type[0]: MultiNodeRunner,
+        MultiNodeRunner.resource_type[1]: MultiNodeRunner,
+    } == runner_map

--- a/dbt_dry_run/test/node_runner/test_snapshot_runner.py
+++ b/dbt_dry_run/test/node_runner/test_snapshot_runner.py
@@ -1,0 +1,242 @@
+from unittest.mock import MagicMock
+
+from dbt_dry_run.literals import enable_test_example_values
+from dbt_dry_run.models import BigQueryFieldType, Table, TableField
+from dbt_dry_run.models.manifest import NodeConfig
+from dbt_dry_run.node_runner.snapshot_runner import SnapshotRunner
+from dbt_dry_run.results import DryRunStatus, Results
+from dbt_dry_run.scheduler import ManifestScheduler
+from dbt_dry_run.test.utils import SimpleNode
+
+enable_test_example_values(True)
+
+A_SIMPLE_TABLE = Table(
+    fields=[
+        TableField(
+            name="a",
+            type=BigQueryFieldType.STRING,
+        )
+    ]
+)
+
+
+def get_executed_sql(mock: MagicMock) -> str:
+    call_args = mock.query.call_args_list
+    assert len(call_args) == 1
+    executed_sql = call_args[0].args[0]
+    return executed_sql
+
+
+def test_snapshot_with_check_all_strategy_runs_sql_with_id() -> None:
+    mock_sql_runner = MagicMock()
+    expected_table = Table(
+        fields=[
+            TableField(
+                name="a",
+                type=BigQueryFieldType.STRING,
+            )
+        ]
+    )
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+
+    node = SimpleNode(
+        unique_id="node1",
+        depends_on=[],
+        resource_type=ManifestScheduler.SNAPSHOT,
+        table_config=NodeConfig(
+            unique_key="a", strategy="check", check_cols="all", materialized="snapshot"
+        ),
+    ).to_node()
+    node.depends_on.deep_nodes = []
+
+    results = Results()
+
+    model_runner = SnapshotRunner(mock_sql_runner, results)
+
+    result = model_runner.run(node)
+    mock_sql_runner.query.assert_called_with(node.compiled_sql)
+    assert (
+        result.status == DryRunStatus.SUCCESS
+    ), f"Failed with error: {result.exception}"
+    assert result.table
+    assert result.table.fields[0].name == expected_table.fields[0].name
+
+
+def test_snapshot_with_check_all_strategy_fails_without_id() -> None:
+    mock_sql_runner = MagicMock()
+    expected_table = Table(
+        fields=[
+            TableField(
+                name="a",
+                type=BigQueryFieldType.STRING,
+            )
+        ]
+    )
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+
+    node = SimpleNode(
+        unique_id="node1",
+        depends_on=[],
+        resource_type=ManifestScheduler.SNAPSHOT,
+        table_config=NodeConfig(
+            unique_key="a_missing_column",
+            strategy="check",
+            check_cols="all",
+            materialized="snapshot",
+        ),
+    ).to_node()
+    node.depends_on.deep_nodes = []
+
+    results = Results()
+
+    model_runner = SnapshotRunner(mock_sql_runner, results)
+
+    result = model_runner.run(node)
+    mock_sql_runner.query.assert_called_with(node.compiled_sql)
+    assert result.status == DryRunStatus.FAILURE
+
+
+def test_snapshot_with_check_all_strategy_runs_sql_with_matching_columns() -> None:
+    mock_sql_runner = MagicMock()
+    expected_table = Table(
+        fields=[
+            TableField(
+                name="a",
+                type=BigQueryFieldType.STRING,
+            ),
+            TableField(
+                name="b",
+                type=BigQueryFieldType.STRING,
+            ),
+        ]
+    )
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+
+    node = SimpleNode(
+        unique_id="node1",
+        depends_on=[],
+        resource_type=ManifestScheduler.SNAPSHOT,
+        table_config=NodeConfig(
+            unique_key="a",
+            strategy="check",
+            check_cols=["a", "b"],
+            materialized="snapshot",
+        ),
+    ).to_node()
+    node.depends_on.deep_nodes = []
+
+    results = Results()
+
+    model_runner = SnapshotRunner(mock_sql_runner, results)
+
+    result = model_runner.run(node)
+    mock_sql_runner.query.assert_called_with(node.compiled_sql)
+    assert (
+        result.status == DryRunStatus.SUCCESS
+    ), f"Failed with error: {result.exception}"
+    assert result.table
+    assert result.table.fields[0].name == expected_table.fields[0].name
+
+
+def test_snapshot_with_check_cols_strategy_fails_with_missing_column() -> None:
+    mock_sql_runner = MagicMock()
+    expected_table = Table(
+        fields=[
+            TableField(
+                name="a",
+                type=BigQueryFieldType.STRING,
+            )
+        ]
+    )
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+
+    node = SimpleNode(
+        unique_id="node1",
+        depends_on=[],
+        resource_type=ManifestScheduler.SNAPSHOT,
+        table_config=NodeConfig(
+            unique_key="a",
+            strategy="check",
+            check_cols=["a", "b"],
+            materialized="snapshot",
+        ),
+    ).to_node()
+    node.depends_on.deep_nodes = []
+
+    results = Results()
+
+    model_runner = SnapshotRunner(mock_sql_runner, results)
+
+    result = model_runner.run(node)
+    mock_sql_runner.query.assert_called_with(node.compiled_sql)
+    assert result.status == DryRunStatus.FAILURE
+
+
+def test_snapshot_with_timestamp_strategy_with_updated_at_column() -> None:
+    mock_sql_runner = MagicMock()
+    expected_table = Table(
+        fields=[
+            TableField(
+                name="a",
+                type=BigQueryFieldType.STRING,
+            ),
+            TableField(name="last_updated_col", type=BigQueryFieldType.TIMESTAMP),
+        ]
+    )
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+
+    node = SimpleNode(
+        unique_id="node1",
+        depends_on=[],
+        resource_type=ManifestScheduler.SNAPSHOT,
+        table_config=NodeConfig(
+            unique_key="a",
+            strategy="timestamp",
+            materialized="snapshot",
+            updated_at="last_updated_col",
+        ),
+    ).to_node()
+    node.depends_on.deep_nodes = []
+
+    results = Results()
+
+    model_runner = SnapshotRunner(mock_sql_runner, results)
+
+    result = model_runner.run(node)
+    mock_sql_runner.query.assert_called_with(node.compiled_sql)
+    assert result.status == DryRunStatus.SUCCESS
+
+
+def test_snapshot_with_timestamp_strategy_with_missing_updated_at_column() -> None:
+    mock_sql_runner = MagicMock()
+    expected_table = Table(
+        fields=[
+            TableField(
+                name="a",
+                type=BigQueryFieldType.STRING,
+            ),
+            TableField(name="last_updated_col", type=BigQueryFieldType.TIMESTAMP),
+        ]
+    )
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+
+    node = SimpleNode(
+        unique_id="node1",
+        depends_on=[],
+        resource_type=ManifestScheduler.SNAPSHOT,
+        table_config=NodeConfig(
+            unique_key="a",
+            strategy="timestamp",
+            materialized="snapshot",
+            updated_at="wrong_last_updated_col",
+        ),
+    ).to_node()
+    node.depends_on.deep_nodes = []
+
+    results = Results()
+
+    model_runner = SnapshotRunner(mock_sql_runner, results)
+
+    result = model_runner.run(node)
+    mock_sql_runner.query.assert_called_with(node.compiled_sql)
+    assert result.status == DryRunStatus.FAILURE

--- a/integration/projects/test_project_with_snapshots/dbt_project.yml
+++ b/integration/projects/test_project_with_snapshots/dbt_project.yml
@@ -1,0 +1,27 @@
+name: 'test_project_with_snapshots'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+# This will get overridden by the root project
+profile: 'default'
+
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "logs"
+
+
+# Configuring models
+models:
+  # This should match your project name
+  test_project_with_snapshots:
+    +enabled: true
+    +materialized: view

--- a/integration/projects/test_project_with_snapshots/models/first_layer.sql
+++ b/integration/projects/test_project_with_snapshots/models/first_layer.sql
@@ -1,0 +1,4 @@
+{{ config(alias="first_layer") }}
+
+SELECT *
+FROM (SELECT "a" as `a`, "b" as `b`, 1 as c)

--- a/integration/projects/test_project_with_snapshots/models/third_layer.sql
+++ b/integration/projects/test_project_with_snapshots/models/third_layer.sql
@@ -1,0 +1,4 @@
+{{ config(alias="third_layer") }}
+
+SELECT *
+FROM {{ ref("second_layer_snapshot") }}

--- a/integration/projects/test_project_with_snapshots/models/third_layer.sql
+++ b/integration/projects/test_project_with_snapshots/models/third_layer.sql
@@ -1,4 +1,4 @@
 {{ config(alias="third_layer") }}
 
 SELECT *
-FROM {{ ref("second_layer_snapshot") }}
+FROM {{ ref("case_check_all_snapshot") }}

--- a/integration/projects/test_project_with_snapshots/snapshots/case_check_all/snapshot.sql
+++ b/integration/projects/test_project_with_snapshots/snapshots/case_check_all/snapshot.sql
@@ -1,0 +1,17 @@
+{% snapshot case_check_all_snapshot %}
+
+{{
+    config(
+      unique_key='a',
+      strategy='check',
+      check_cols='all',
+      target_schema='dry_run'
+    )
+}}
+
+select a,
+       b,
+       c
+from {{ ref("first_layer") }}
+
+{% endsnapshot %}

--- a/integration/projects/test_project_with_snapshots/snapshots/case_check_invalid_column/snapshot.sql
+++ b/integration/projects/test_project_with_snapshots/snapshots/case_check_invalid_column/snapshot.sql
@@ -1,0 +1,17 @@
+{% snapshot case_check_invalid_column_snapshot %}
+
+{{
+    config(
+      unique_key='a',
+      strategy='check',
+      check_cols=["wrong_column"],
+      target_schema='dry_run'
+    )
+}}
+
+select a,
+       b,
+       c
+from {{ ref("first_layer") }}
+
+{% endsnapshot %}

--- a/integration/projects/test_project_with_snapshots/snapshots/case_check_single_column/snapshot.sql
+++ b/integration/projects/test_project_with_snapshots/snapshots/case_check_single_column/snapshot.sql
@@ -1,0 +1,17 @@
+{% snapshot case_check_single_column_snapshot %}
+
+{{
+    config(
+      unique_key='a',
+      strategy='check',
+      check_cols=["a"],
+      target_schema='dry_run'
+    )
+}}
+
+select a,
+       b,
+       c
+from {{ ref("first_layer") }}
+
+{% endsnapshot %}

--- a/integration/projects/test_project_with_snapshots/snapshots/case_invalid_timestamp_column/snapshot.sql
+++ b/integration/projects/test_project_with_snapshots/snapshots/case_invalid_timestamp_column/snapshot.sql
@@ -1,0 +1,16 @@
+{% snapshot case_invalid_timestamp_column_snapshot %}
+
+{{
+    config(
+      unique_key='a',
+      strategy='timestamp',
+      updated_at='updated_at_wrong',
+      target_schema='dry_run'
+    )
+}}
+
+select *,
+       DATE("2021-01-01") as updated_at
+from {{ ref("first_layer") }}
+
+{% endsnapshot %}

--- a/integration/projects/test_project_with_snapshots/snapshots/case_invalid_unique_key/snapshot.sql
+++ b/integration/projects/test_project_with_snapshots/snapshots/case_invalid_unique_key/snapshot.sql
@@ -1,0 +1,17 @@
+{% snapshot case_invalid_unique_key_snapshot %}
+
+{{
+    config(
+      unique_key='wrong_column',
+      strategy='check',
+      check_cols='all',
+      target_schema='dry_run'
+    )
+}}
+
+select a,
+       b,
+       c
+from {{ ref("first_layer") }}
+
+{% endsnapshot %}

--- a/integration/projects/test_project_with_snapshots/snapshots/case_timestamp_column/snapshot.sql
+++ b/integration/projects/test_project_with_snapshots/snapshots/case_timestamp_column/snapshot.sql
@@ -1,4 +1,4 @@
-{% snapshot second_layer_snapshot %}
+{% snapshot case_timestamp_column_snapshot %}
 
 {{
     config(

--- a/integration/projects/test_project_with_snapshots/snapshots/second_layer.sql
+++ b/integration/projects/test_project_with_snapshots/snapshots/second_layer.sql
@@ -1,0 +1,16 @@
+{% snapshot second_layer_snapshot %}
+
+{{
+    config(
+      unique_key='a',
+      strategy='timestamp',
+      updated_at='updated_at',
+      target_schema='dry_run'
+    )
+}}
+
+select *,
+       DATE("2021-01-01") as updated_at
+from {{ ref("first_layer") }}
+
+{% endsnapshot %}

--- a/integration/projects/test_project_with_snapshots/test_project_with_snapshots.py
+++ b/integration/projects/test_project_with_snapshots/test_project_with_snapshots.py
@@ -1,11 +1,44 @@
+from dbt_dry_run.node_runner.snapshot_runner import DBT_SNAPSHOT_FIELDS
 from integration.conftest import IntegrationTestResult
-from integration.utils import assert_report_success, get_report_node_by_id, assert_report_node_has_columns
+from integration.utils import get_report_node_by_id, assert_report_node_has_columns
+
+DBT_SNAPSHOT_COLUMN_NAMES = set([field.name for field in DBT_SNAPSHOT_FIELDS])
 
 
-def test_success(dry_run_result: IntegrationTestResult):
-    assert assert_report_success(dry_run_result)
+def test_case_invalid_unique_key_fails(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "snapshot.test_project_with_snapshots.case_invalid_unique_key_snapshot")
+    assert not node.success
+    assert node.error_message == "SnapshotConfigException"
 
 
-def test_snapshot_schema_predicted(dry_run_result: IntegrationTestResult):
-    node_id = get_report_node_by_id(dry_run_result.report, "snapshot.test_project_with_snapshots.second_layer_snapshot")
-    assert_report_node_has_columns(node_id, {"a", "b", "c", 'updated_at'})
+def test_case_timestamp_column_succeeds(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "snapshot.test_project_with_snapshots.case_timestamp_column_snapshot")
+    assert_report_node_has_columns(node, {"a", "b", "c", "updated_at", *DBT_SNAPSHOT_COLUMN_NAMES})
+
+
+def test_case_invalid_timestamp_column_fails(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "snapshot.test_project_with_snapshots.case_invalid_timestamp_column_snapshot")
+    assert not node.success
+    assert node.error_message == "SnapshotConfigException"
+
+
+def test_case_all_succeeds(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "snapshot.test_project_with_snapshots.case_check_all_snapshot")
+    assert_report_node_has_columns(node, {"a", "b", "c", *DBT_SNAPSHOT_COLUMN_NAMES})
+
+
+def test_case_single_column_succeeds(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "snapshot.test_project_with_snapshots.case_check_single_column_snapshot")
+    assert_report_node_has_columns(node, {"a", "b", "c", *DBT_SNAPSHOT_COLUMN_NAMES})
+
+
+def test_case_invalid_column_fails(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "snapshot.test_project_with_snapshots.case_check_invalid_column_snapshot")
+    assert not node.success
+    assert node.error_message == "SnapshotConfigException"

--- a/integration/projects/test_project_with_snapshots/test_project_with_snapshots.py
+++ b/integration/projects/test_project_with_snapshots/test_project_with_snapshots.py
@@ -1,0 +1,11 @@
+from integration.conftest import IntegrationTestResult
+from integration.utils import assert_report_success, get_report_node_by_id, assert_report_node_has_columns
+
+
+def test_success(dry_run_result: IntegrationTestResult):
+    assert assert_report_success(dry_run_result)
+
+
+def test_snapshot_schema_predicted(dry_run_result: IntegrationTestResult):
+    node_id = get_report_node_by_id(dry_run_result.report, "snapshot.test_project_with_snapshots.second_layer_snapshot")
+    assert_report_node_has_columns(node_id, {"a", "b", "c", 'updated_at'})

--- a/integration/utils.py
+++ b/integration/utils.py
@@ -34,4 +34,5 @@ def assert_node_was_successful(report: Report, unique_id: str) -> None:
 
 
 def assert_report_node_has_columns(node: ReportNode, columns: Set[str]) -> None:
-    assert set(map(lambda field: field.name, node.table.fields)) == columns
+    column_names = set(map(lambda field: field.name, node.table.fields))
+    assert column_names == columns, f"Report node {node.unique_id} columns: {column_names} does not have expected columns: {columns}"

--- a/integration/utils.py
+++ b/integration/utils.py
@@ -10,7 +10,7 @@ def assert_report_produced(result: IntegrationTestResult) -> Report:
 
 
 def assert_report_success(result: IntegrationTestResult) -> Report:
-    assert result.report
+    assert result.report, f"Repost is missing: {result.process.stdout}"
     assert result.report.success
     return result.report
 

--- a/run-integration.sh
+++ b/run-integration.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+project_name=$1
+command=${2:-compile}
+dbt "$command" --profiles-dir ./integration/profiles --target integration-local --project-dir ./integration/projects/"$project_name"
+python3 -m dbt_dry_run default --profiles-dir ./integration/profiles --target integration-local --manifest-path ./integration/projects/"$project_name"/target/manifest.json --report-path ./integration/projects/"$project_name"/target/dry_run.json


### PR DESCRIPTION
This PR adds support for dbt snapshots. The dry runner can now predict the schema of snapshot models and catch configuration issues such as:

1. Missing/incorrect `unique_key` in the snapshots schema
2. Missing/incorrect `updated_at` column
3. Missing/incorrect `check_cols`