### PR TITLE
Casting numeric fields to the right type

### DIFF
--- a/dbt_dry_run/literals.py
+++ b/dbt_dry_run/literals.py
@@ -21,8 +21,8 @@ _EXAMPLE_VALUES: Dict[BigQueryFieldType, Callable[[], str]] = {
     BigQueryFieldType.TIME: lambda: "TIME(12,0,0)",
     BigQueryFieldType.DATETIME: lambda: "DATETIME(2021,1,1,12,0,0)",
     BigQueryFieldType.GEOGRAPHY: lambda: "ST_GeogPoint(0.0, 0.0)",
-    BigQueryFieldType.NUMERIC: lambda: "1",
-    BigQueryFieldType.BIGNUMERIC: lambda: "2",
+    BigQueryFieldType.NUMERIC: lambda: "CAST(1 AS NUMERIC)",
+    BigQueryFieldType.BIGNUMERIC: lambda: "CAST(2 AS BIGNUMERIC)",
 }
 
 _EXAMPLE_VALUES_TEST: Dict[BigQueryFieldType, Callable[[], str]] = {
@@ -39,8 +39,8 @@ _EXAMPLE_VALUES_TEST: Dict[BigQueryFieldType, Callable[[], str]] = {
     BigQueryFieldType.TIME: lambda: "TIME(12,0,0)",
     BigQueryFieldType.DATETIME: lambda: "DATETIME(2021,1,1,12,0,0)",
     BigQueryFieldType.GEOGRAPHY: lambda: "ST_GeogPoint(0.0, 0.0)",
-    BigQueryFieldType.NUMERIC: lambda: "1",
-    BigQueryFieldType.BIGNUMERIC: lambda: "2",
+    BigQueryFieldType.NUMERIC: lambda: "CAST(1 AS NUMERIC)",
+    BigQueryFieldType.BIGNUMERIC: lambda: "CAST(2 AS BIGNUMERIC)",
 }
 
 _ACTIVE_EXAMPLE_VALUES = _EXAMPLE_VALUES


### PR DESCRIPTION
# Description

Casting numeric types as `NUMERIC` and `BIGNUMERIC` in the when building `SELECT` literals, otherwise they will be treated as `INT64`

Fixes #12 

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [ ] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
