### PR TITLE
Replacing `_dbt_max_partition` in incremental models that have a `partition_by` field

### DIFF
--- a/dbt_dry_run/literals.py
+++ b/dbt_dry_run/literals.py
@@ -21,8 +21,8 @@ _EXAMPLE_VALUES: Dict[BigQueryFieldType, Callable[[], str]] = {
     BigQueryFieldType.TIME: lambda: "TIME(12,0,0)",
     BigQueryFieldType.DATETIME: lambda: "DATETIME(2021,1,1,12,0,0)",
     BigQueryFieldType.GEOGRAPHY: lambda: "ST_GeogPoint(0.0, 0.0)",
-    BigQueryFieldType.NUMERIC: lambda: "1",
-    BigQueryFieldType.BIGNUMERIC: lambda: "2",
+    BigQueryFieldType.NUMERIC: lambda: "CAST(1 AS NUMERIC)",
+    BigQueryFieldType.BIGNUMERIC: lambda: "CAST(2 AS BIGNUMERIC)",
 }
 
 _EXAMPLE_VALUES_TEST: Dict[BigQueryFieldType, Callable[[], str]] = {
@@ -39,8 +39,8 @@ _EXAMPLE_VALUES_TEST: Dict[BigQueryFieldType, Callable[[], str]] = {
     BigQueryFieldType.TIME: lambda: "TIME(12,0,0)",
     BigQueryFieldType.DATETIME: lambda: "DATETIME(2021,1,1,12,0,0)",
     BigQueryFieldType.GEOGRAPHY: lambda: "ST_GeogPoint(0.0, 0.0)",
-    BigQueryFieldType.NUMERIC: lambda: "1",
-    BigQueryFieldType.BIGNUMERIC: lambda: "2",
+    BigQueryFieldType.NUMERIC: lambda: "CAST(1 AS NUMERIC)",
+    BigQueryFieldType.BIGNUMERIC: lambda: "CAST(2 AS BIGNUMERIC)",
 }
 
 _ACTIVE_EXAMPLE_VALUES = _EXAMPLE_VALUES

--- a/dbt_dry_run/models/manifest.py
+++ b/dbt_dry_run/models/manifest.py
@@ -19,6 +19,18 @@ class OnSchemaChange(str, Enum):
     SYNC_ALL_COLUMNS = "sync_all_columns"
 
 
+class BqPartitionRange(BaseModel):
+    start: int
+    end: int
+    interval: int
+
+
+class PartitionBy(BaseModel):
+    field: str
+    data_type: Literal["timestamp", "date", "datetime", "int64"]
+    range: Optional[BqPartitionRange]
+
+
 class NodeConfig(BaseModel):
     materialized: str
     on_schema_change: Optional[OnSchemaChange]
@@ -27,6 +39,7 @@ class NodeConfig(BaseModel):
     updated_at: Optional[str]
     strategy: Union[None, Literal["timestamp", "check"]]
     check_cols: Optional[Union[Literal["all"], List[str]]]
+    partition_by: Optional[PartitionBy]
 
 
 class Node(BaseModel):

--- a/dbt_dry_run/models/manifest.py
+++ b/dbt_dry_run/models/manifest.py
@@ -19,7 +19,7 @@ class OnSchemaChange(str, Enum):
     SYNC_ALL_COLUMNS = "sync_all_columns"
 
 
-class BqPartitionRange(BaseModel):
+class IntPartitionRange(BaseModel):
     start: int
     end: int
     interval: int
@@ -28,7 +28,7 @@ class BqPartitionRange(BaseModel):
 class PartitionBy(BaseModel):
     field: str
     data_type: Literal["timestamp", "date", "datetime", "int64"]
-    range: Optional[BqPartitionRange]
+    range: Optional[IntPartitionRange]
 
 
 class NodeConfig(BaseModel):

--- a/dbt_dry_run/node_runner/model_runner.py
+++ b/dbt_dry_run/node_runner/model_runner.py
@@ -84,7 +84,11 @@ class ModelRunner(NodeRunner):
         if node.config.materialized == "view":
             sql_statement = f"CREATE OR REPLACE VIEW `{node.database}`.`{node.db_schema}`.`{node.alias}` AS (\n{sql_statement}\n)"
 
-        if node.config.materialized == "incremental" and node.config.partition_by:
+        if (
+            node.config.materialized == "incremental"
+            and node.config.partition_by
+            and "_dbt_max_partition" in node.compiled_sql
+        ):
             dbt_max_partition_declaration = (
                 f"declare _dbt_max_partition {node.config.partition_by.data_type} default"
                 f" {PARTITION_DATA_TYPES_VALUES_MAPPING[node.config.partition_by.data_type]};"

--- a/dbt_dry_run/test/node_runner/test_model_runner.py
+++ b/dbt_dry_run/test/node_runner/test_model_runner.py
@@ -79,7 +79,7 @@ def test_model_as_view_runs_create_view() -> None:
 
 
 def test_partitioned_incremental_model_declares_dbt_max_partition_variable() -> None:
-    DBT_MAX_PARTITION_DECLARATION = (
+    dbt_max_partition_declaration = (
         "declare _dbt_max_partition timestamp default CURRENT_TIMESTAMP();"
     )
     mock_sql_runner = MagicMock()
@@ -110,7 +110,7 @@ def test_partitioned_incremental_model_declares_dbt_max_partition_variable() -> 
     model_runner.run(node)
 
     executed_sql = get_executed_sql(mock_sql_runner)
-    assert executed_sql.startswith(DBT_MAX_PARTITION_DECLARATION)
+    assert executed_sql.startswith(dbt_max_partition_declaration)
     assert node.compiled_sql in executed_sql
 
 


### PR DESCRIPTION
# Description

See title

Fixes #10 

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
