### PR TITLE
Support list of strings for incremental unique_key

### DIFF
--- a/dbt_dry_run/models/manifest.py
+++ b/dbt_dry_run/models/manifest.py
@@ -40,7 +40,7 @@ class NodeConfig(BaseModel):
     materialized: str
     on_schema_change: Optional[OnSchemaChange]
     sql_header: Optional[str]
-    unique_key: Optional[str]
+    unique_key: Optional[Union[str, List[str]]]
     updated_at: Optional[str]
     strategy: Union[None, Literal["timestamp", "check"]]
     check_cols: Optional[Union[Literal["all"], List[str]]]

--- a/dbt_dry_run/node_runner/snapshot_runner.py
+++ b/dbt_dry_run/node_runner/snapshot_runner.py
@@ -45,6 +45,11 @@ class SnapshotRunner(NodeRunner):
     def _validate_snapshot_config(node: Node, result: DryRunResult) -> DryRunResult:
         if not result.table:
             raise ValueError("Can't validate result without table")
+        if isinstance(node.config.unique_key, list):
+            raise RuntimeError(
+                f"Cannot dry run node '{node.unique_id}' because it is a snapshot"
+                f" with a list of unique keys '{node.config.unique_key}'"
+            )
         if node.config.unique_key not in result.table.field_names:
             exception = SnapshotConfigException(
                 f"Missing `unique_key` column '{node.config.unique_key}'"


### PR DESCRIPTION
# Description

In dbt 1.1 support was added for `unique_key` to be a list of strings as well as just a string. The dry runner fails to validate the manifest if a project uses this feature. This PR changes the pydantic model to allow list of strings for `unique_key`. It also verifies that the snapshot model does not have a list of `unique_key` in case dbt adds this same feature to snapshot models and we need to update the node runner to handle this.

Fixes #18 

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
