### PR TITLE
Column Metadata Linting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 ## Changelog
 
+# dbt-dry-run v0.5.0
+
+## Improvements & Bugfixes
+
+- Add support for column metadata linting/validation. Mark a model in its metadata with `dry_run.check_columns: true`
+  to enable checks that ensure that column names in the predicted dbt project schema match the columns in the metadata
+  see the `README.md` for more info, failure will be reporting as a `LINTING` error:
+  
+  ```text
+  Dry running X models
+  Node model.test_column_linting.badly_documented_model failed linting with rule violations:
+          UNDOCUMENTED_COLUMNS : Column not documented in metadata: 'c'
+          EXTRA_DOCUMENTED_COLUMNS : Extra column in metadata: 'd'
+  
+  Total 1 failures:
+  1       :       model.test_column_linting.badly_documented_model        :       LINTING :       ERROR
+  DRY RUN FAILURE!
+  ```
+
 # dbt-dry-run v0.4.2
 
 ## Improvements & Bugfixes

--- a/dbt_dry_run/adapter/service.py
+++ b/dbt_dry_run/adapter/service.py
@@ -1,5 +1,4 @@
 import os
-from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Optional
 
@@ -47,6 +46,7 @@ class ProjectService:
 
     def get_dbt_manifest(self) -> Manifest:
         manifest = Manifest.from_filepath(self.manifest_filepath)
+
         return manifest
 
     @property

--- a/dbt_dry_run/cli.py
+++ b/dbt_dry_run/cli.py
@@ -8,6 +8,7 @@ from typer import Argument, Option
 from dbt_dry_run.adapter.service import DbtArgs, ProjectService
 from dbt_dry_run.exception import ManifestValidationError
 from dbt_dry_run.execution import dry_run_manifest
+from dbt_dry_run.linting.column_linting import lint_columns
 from dbt_dry_run.result_reporter import ResultReporter
 
 app = typer.Typer()
@@ -32,15 +33,18 @@ def dry_run(
     try:
         dry_run_results = dry_run_manifest(project)
         reporter = ResultReporter(dry_run_results, set(), verbose)
-        exit_code = reporter.report_and_check_results()
+        exit_code = reporter.report_and_check_results()]
+
+        report = reporter.get_report()
+
         if report_path:
-            reporter.write_results_artefact(report_path)
+            with open(report_path, "w") as f:
+                f.write(report.json(by_alias=True))
 
     except ManifestValidationError as e:
         print("Dry run failed to validate manifest")
         print(str(e))
         exit_code = 1
-
     return exit_code
 
 

--- a/dbt_dry_run/cli.py
+++ b/dbt_dry_run/cli.py
@@ -8,7 +8,6 @@ from typer import Argument, Option
 from dbt_dry_run.adapter.service import DbtArgs, ProjectService
 from dbt_dry_run.exception import ManifestValidationError
 from dbt_dry_run.execution import dry_run_manifest
-from dbt_dry_run.linting.column_linting import lint_columns
 from dbt_dry_run.result_reporter import ResultReporter
 
 app = typer.Typer()

--- a/dbt_dry_run/cli.py
+++ b/dbt_dry_run/cli.py
@@ -32,7 +32,7 @@ def dry_run(
     try:
         dry_run_results = dry_run_manifest(project)
         reporter = ResultReporter(dry_run_results, set(), verbose)
-        exit_code = reporter.report_and_check_results()]
+        exit_code = reporter.report_and_check_results()
 
         report = reporter.get_report()
 

--- a/dbt_dry_run/execution.py
+++ b/dbt_dry_run/execution.py
@@ -46,7 +46,7 @@ def dry_run_node(runners: Dict[str, NodeRunner], node: Node, results: Results) -
     """
     if node.compiled:
         dry_run_result = dispatch_node(node, runners)
-        if node.config.meta and node.config.meta.check_columns:
+        if node.get_should_check_columns():
             dry_run_result = lint_columns(node, dry_run_result)
         results.add_result(node.unique_id, dry_run_result)
     else:

--- a/dbt_dry_run/execution.py
+++ b/dbt_dry_run/execution.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple
 
 from dbt_dry_run.adapter.service import ProjectService
+from dbt_dry_run.linting.column_linting import lint_columns
 from dbt_dry_run.node_runner.snapshot_runner import SnapshotRunner
 from dbt_dry_run.sql_runner import SQLRunner
 
@@ -45,6 +46,8 @@ def dry_run_node(runners: Dict[str, NodeRunner], node: Node, results: Results) -
     """
     if node.compiled:
         dry_run_result = dispatch_node(node, runners)
+        if node.config.meta and node.config.meta.check_columns:
+            dry_run_result = lint_columns(node, dry_run_result)
         results.add_result(node.unique_id, dry_run_result)
     else:
         not_compiled_result = DryRunResult(

--- a/dbt_dry_run/linting/column_linting.py
+++ b/dbt_dry_run/linting/column_linting.py
@@ -1,0 +1,54 @@
+from typing import Callable, Dict, List
+
+from dbt_dry_run.models import Table
+from dbt_dry_run.models.manifest import ManifestColumn, Node
+from dbt_dry_run.results import ColumnError, DryRunResult
+
+
+def get_extra_documented_columns(
+    manifest: Dict[str, ManifestColumn], dry_run: Table
+) -> List[str]:
+    dry_run_column_names = list(map(lambda field: field.name, dry_run.fields))
+    extra_columns_in_manifest = set(manifest.keys()) - set(dry_run_column_names)
+    errors = []
+
+    if extra_columns_in_manifest:
+        for column in extra_columns_in_manifest:
+            errors.append(f"Extra column in metadata: '{column}'")
+
+    return errors
+
+
+def get_undocumented_columns(
+    manifest: Dict[str, ManifestColumn], dry_run: Table
+) -> List[str]:
+    dry_run_column_names = list(map(lambda field: field.name, dry_run.fields))
+    missing_columns_in_manifest = set(dry_run_column_names) - set(manifest.keys())
+
+    errors = []
+    if missing_columns_in_manifest:
+        for column in missing_columns_in_manifest:
+            errors.append(f"Column not documented in metadata: '{column}'")
+
+    return errors
+
+
+RULES: Dict[str, Callable[[Dict[str, ManifestColumn], Table], List[str]]] = {
+    "UNDOCUMENTED_COLUMNS": get_undocumented_columns,
+    "EXTRA_DOCUMENTED_COLUMNS": get_extra_documented_columns,
+}
+
+
+def lint_columns(node: Node, result: DryRunResult) -> DryRunResult:
+    if not result.table:
+        return result
+
+    all_errors = []
+
+    for rule_name, rule_func in RULES.items():
+        error_messages = rule_func(node.columns, result.table)
+        errors = list(
+            map(lambda err: ColumnError(rule=rule_name, message=err), error_messages)
+        )
+        all_errors.extend(errors)
+    return result.with_column_errors(all_errors)

--- a/dbt_dry_run/linting/column_linting.py
+++ b/dbt_dry_run/linting/column_linting.py
@@ -1,8 +1,8 @@
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Set
 
 from dbt_dry_run.models import Table, TableField
 from dbt_dry_run.models.manifest import ManifestColumn, Node
-from dbt_dry_run.results import ColumnError, DryRunResult
+from dbt_dry_run.results import DryRunResult, LintingError
 
 
 def _extract_fields(table_fields: List[TableField], prefix: str = "") -> List[str]:
@@ -68,7 +68,7 @@ def lint_columns(node: Node, result: DryRunResult) -> DryRunResult:
     for rule_name, rule_func in RULES.items():
         error_messages = rule_func(node.columns, result.table)
         errors = list(
-            map(lambda err: ColumnError(rule=rule_name, message=err), error_messages)
+            map(lambda err: LintingError(rule=rule_name, message=err), error_messages)
         )
         all_errors.extend(errors)
-    return result.with_column_errors(all_errors)
+    return result.with_linting_errors(all_errors)

--- a/dbt_dry_run/models/manifest.py
+++ b/dbt_dry_run/models/manifest.py
@@ -36,6 +36,10 @@ class PartitionBy(BaseModel):
         return values
 
 
+class NodeMeta(BaseModel):
+    check_columns: bool = Field(False, alias="dry_run.check_columns")
+
+
 class NodeConfig(BaseModel):
     materialized: str
     on_schema_change: Optional[OnSchemaChange]
@@ -45,6 +49,12 @@ class NodeConfig(BaseModel):
     strategy: Union[None, Literal["timestamp", "check"]]
     check_cols: Optional[Union[Literal["all"], List[str]]]
     partition_by: Optional[PartitionBy]
+    meta: Optional[NodeMeta]
+
+
+class ManifestColumn(BaseModel):
+    name: str
+    description: Optional[str]
 
 
 class Node(BaseModel):
@@ -61,6 +71,7 @@ class Node(BaseModel):
     resource_type: str
     original_file_path: str
     root_path: str
+    columns: Dict[str, ManifestColumn]
 
     def __init__(self, **data: Any):
         super().__init__(

--- a/dbt_dry_run/models/report.py
+++ b/dbt_dry_run/models/report.py
@@ -3,7 +3,13 @@ from typing import List, Optional
 from pydantic import Field
 from pydantic.main import BaseModel
 
+from ..results import LintingStatus
 from .table import Table
+
+
+class ReportLintingError(BaseModel):
+    rule: str
+    message: str
 
 
 class ReportNode(BaseModel):
@@ -11,6 +17,8 @@ class ReportNode(BaseModel):
     success: bool
     error_message: Optional[str]
     table: Optional[Table]
+    linting_status: LintingStatus
+    linting_errors: List[ReportLintingError]
 
 
 class Report(BaseModel):

--- a/dbt_dry_run/result_reporter.py
+++ b/dbt_dry_run/result_reporter.py
@@ -4,9 +4,9 @@ from typing import List, Set, Tuple
 from dbt_dry_run.models import Report, ReportNode
 from dbt_dry_run.models.report import ReportLintingError
 from dbt_dry_run.results import (
-    ColumnError,
     DryRunResult,
     DryRunStatus,
+    LintingError,
     LintingStatus,
     Results,
 )
@@ -15,7 +15,7 @@ QUERY_JOB_SQL_FOLLOWS = "-----Query Job SQL Follows-----"
 QUERY_JOB_HEADER = re.compile(r"|    .    ", re.MULTILINE)
 
 
-def _map_column_errors(column_errors: List[ColumnError]) -> List[ReportLintingError]:
+def _map_column_errors(column_errors: List[LintingError]) -> List[ReportLintingError]:
     return list(
         map(
             lambda err: ReportLintingError(rule=err.rule, message=err.message),

--- a/dbt_dry_run/result_reporter.py
+++ b/dbt_dry_run/result_reporter.py
@@ -2,10 +2,26 @@ import re
 from typing import List, Set, Tuple
 
 from dbt_dry_run.models import Report, ReportNode
-from dbt_dry_run.results import DryRunResult, DryRunStatus, Results
+from dbt_dry_run.models.report import ReportLintingError
+from dbt_dry_run.results import (
+    ColumnError,
+    DryRunResult,
+    DryRunStatus,
+    LintingStatus,
+    Results,
+)
 
 QUERY_JOB_SQL_FOLLOWS = "-----Query Job SQL Follows-----"
 QUERY_JOB_HEADER = re.compile(r"|    .    ", re.MULTILINE)
+
+
+def _map_column_errors(column_errors: List[ColumnError]) -> List[ReportLintingError]:
+    return list(
+        map(
+            lambda err: ReportLintingError(rule=err.rule, message=err.message),
+            column_errors,
+        )
+    )
 
 
 class ResultReporter:
@@ -28,7 +44,7 @@ class ResultReporter:
                 f"{index + 1}\t:\t{failure.node.unique_id}\t:\t{exception_col}\t:\t{excluded_col}"
             )
 
-    def write_results_artefact(self, output_path: str) -> None:
+    def get_report(self) -> Report:
         report_nodes: List[ReportNode] = []
         success = True
         node_count = 0
@@ -44,11 +60,13 @@ class ResultReporter:
                 success=result.status == DryRunStatus.SUCCESS,
                 error_message=exception_type,
                 table=result.table,
+                linting_status=result.linting_status,
+                linting_errors=_map_column_errors(result.linting_errors),
             )
             report_nodes.append(new_node)
 
             node_count += 1
-            if not new_node.success:
+            if not new_node.success or new_node.linting_status == LintingStatus.FAILURE:
                 success = False
                 failure_count += 1
                 failed_node_ids.append(new_node.unique_id)
@@ -62,8 +80,7 @@ class ResultReporter:
             nodes=report_nodes,
         )
 
-        with open(output_path, "w") as f:
-            f.write(report.json(by_alias=True))
+        return report
 
     def report_and_check_results(self) -> int:
         failures: List[Tuple[DryRunResult, bool]] = []
@@ -72,8 +89,16 @@ class ResultReporter:
                 print(f"Node {result.node.unique_id} failed with exception:")
                 self._print_full_exception(result.exception)
                 failures.append((result, result.node.unique_id in self._exclude))
-        print("")
+            elif result.linting_status == LintingStatus.FAILURE:
+                print(
+                    f"Node {result.node.unique_id} failed linting with rule violations:"
+                )
+                for err in result.linting_errors:
+                    print(f"\t{err.rule} : {err.message}")
+                failures.append((result, False))
+
         if failures:
+            print("")
             self._report_failure_summary(failures)
         included_failures = [f for f in failures if not f[1]]
 

--- a/dbt_dry_run/result_reporter.py
+++ b/dbt_dry_run/result_reporter.py
@@ -37,6 +37,8 @@ class ResultReporter:
         for index, (failure, excluded) in enumerate(failures):
             if failure.exception:
                 exception_col = failure.exception.__class__.__name__
+            elif failure.linting_status == LintingStatus.FAILURE:
+                exception_col = "LINTING"
             else:
                 exception_col = "UNKNOWN"
             excluded_col = "EXCLUDED" if excluded else "ERROR"

--- a/dbt_dry_run/results.py
+++ b/dbt_dry_run/results.py
@@ -20,7 +20,7 @@ class LintingStatus(str, Enum):
 
 
 @dataclass(frozen=True)
-class ColumnError:
+class LintingError:
     rule: str
     message: str
 
@@ -32,15 +32,15 @@ class DryRunResult:
     status: DryRunStatus
     exception: Optional[Exception]
     linting_status: LintingStatus = LintingStatus.SKIPPED
-    linting_errors: List[ColumnError] = field(default_factory=lambda: [])
+    linting_errors: List[LintingError] = field(default_factory=lambda: [])
 
     def replace_table(self, table: Table) -> "DryRunResult":
         return DryRunResult(
             node=self.node, table=table, status=self.status, exception=self.exception
         )
 
-    def with_column_errors(self, column_errors: List[ColumnError]) -> "DryRunResult":
-        if column_errors:
+    def with_linting_errors(self, linting_errors: List[LintingError]) -> "DryRunResult":
+        if linting_errors:
             linting_status = LintingStatus.FAILURE
         else:
             linting_status = LintingStatus.SUCCESS
@@ -49,7 +49,7 @@ class DryRunResult:
             table=self.table,
             status=self.status,
             exception=self.exception,
-            linting_errors=column_errors,
+            linting_errors=linting_errors,
             linting_status=linting_status,
         )
 

--- a/dbt_dry_run/test/linting/test_column_linting.py
+++ b/dbt_dry_run/test/linting/test_column_linting.py
@@ -1,0 +1,106 @@
+from typing import List, Optional
+
+from dbt_dry_run.linting.column_linting import (
+    expand_table_fields,
+    get_extra_documented_columns,
+    get_undocumented_columns,
+)
+from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, Table, TableField
+from dbt_dry_run.models.manifest import ManifestColumn
+
+
+def field_with_name(
+    name: str,
+    type_: BigQueryFieldType = BigQueryFieldType.STRING,
+    mode: BigQueryFieldMode = BigQueryFieldMode.NULLABLE,
+    fields: Optional[List[TableField]] = None,
+) -> TableField:
+    return TableField(name=name, type=type_, mode=mode, fields=fields)
+
+
+def test_expand_table_fields_with_column_names_with_no_nesting() -> None:
+    table = Table(fields=[field_with_name("a"), field_with_name("b")])
+
+    expected = {"a", "b"}
+    actual = expand_table_fields(table)
+    assert actual == expected
+
+
+def test_expand_table_fields_with_struct() -> None:
+    table = Table(
+        fields=[
+            field_with_name("a"),
+            field_with_name(
+                "struct",
+                fields=[field_with_name("struct_1"), field_with_name("struct_2")],
+            ),
+        ]
+    )
+
+    expected = {"a", "struct", "struct.struct_1", "struct.struct_2"}
+    actual = expand_table_fields(table)
+    assert actual == expected
+
+
+def test_expand_table_fields_with_nested_struct() -> None:
+    table = Table(
+        fields=[
+            field_with_name("a"),
+            field_with_name(
+                "struct",
+                fields=[
+                    field_with_name("struct_1", fields=[field_with_name("struct_1_1")])
+                ],
+            ),
+        ]
+    )
+
+    expected = {"a", "struct", "struct.struct_1", "struct.struct_1.struct_1_1"}
+    actual = expand_table_fields(table)
+    assert actual == expected
+
+
+def test_get_extra_documented_columns_passes_if_no_extra_columns() -> None:
+    table = Table(fields=[field_with_name("a")])
+    manifest_columns = {"a": ManifestColumn(name="a", description="a column")}
+
+    expected: List[str] = []
+    actual = get_extra_documented_columns(manifest_columns, table)
+
+    assert actual == expected
+
+
+def test_get_extra_documented_columns_fails_if_extra_columns() -> None:
+    table = Table(fields=[field_with_name("a")])
+    manifest_columns = {
+        "a": ManifestColumn(name="a", description="a column"),
+        "b": ManifestColumn(name="a", description="an extra column"),
+    }
+
+    expected = ["Extra column in metadata: 'b'"]
+    actual = get_extra_documented_columns(manifest_columns, table)
+
+    assert actual == expected
+
+
+def test_get_undocumented_columns_passes_if_all_columns_present() -> None:
+    table = Table(fields=[field_with_name("a")])
+    manifest_columns = {"a": ManifestColumn(name="a", description="a column")}
+
+    expected: List[str] = []
+    actual = get_undocumented_columns(manifest_columns, table)
+
+    assert actual == expected
+
+
+def test_get_undocumented_columns_fails_if_undocumented_columns() -> None:
+    table = Table(fields=[field_with_name("a"), field_with_name("b")])
+    manifest_columns = {
+        "a": ManifestColumn(name="a", description="a column"),
+        "c": ManifestColumn(name="c", description="an extra column"),
+    }
+
+    expected = ["Column not documented in metadata: 'b'"]
+    actual = get_undocumented_columns(manifest_columns, table)
+
+    assert actual == expected

--- a/dbt_dry_run/test/models/test_manifest.py
+++ b/dbt_dry_run/test/models/test_manifest.py
@@ -1,7 +1,46 @@
-from dbt_dry_run.models.manifest import PartitionBy
+import pytest
+
+from dbt_dry_run.models.manifest import Node, NodeConfig, NodeMeta, PartitionBy
+from dbt_dry_run.test.utils import SimpleNode
 
 
 def test_partition_by_config_case_insensitive() -> None:
     partition_by = PartitionBy(field="a_field", data_type="TIMESTAMP")
     assert partition_by.field == "a_field"
     assert partition_by.data_type == "timestamp"
+
+
+def test_node_get_should_check_columns_defaults_to_false() -> None:
+    config = NodeConfig(materialized="table", meta=None)
+    node = SimpleNode(
+        unique_id="a", depends_on=[], table_config=config, meta=None
+    ).to_node()
+
+    assert node.get_should_check_columns() is False
+
+
+def test_node_get_should_check_columns_inherits_from_node_meta() -> None:
+    config = NodeConfig(materialized="table", meta=None)
+    node = SimpleNode(
+        unique_id="a",
+        depends_on=[],
+        table_config=config,
+        meta=NodeMeta(check_columns=True),
+    ).to_node()
+
+    assert node.get_should_check_columns() is True
+
+
+@pytest.mark.parametrize("config_meta", [False, True])
+def test_node_get_should_check_columns_is_overriden_by_config(
+    config_meta: bool,
+) -> None:
+    config = NodeConfig(materialized="table", meta=NodeMeta(check_columns=config_meta))
+    node = SimpleNode(
+        unique_id="a",
+        depends_on=[],
+        table_config=config,
+        meta=NodeMeta(check_columns=not config_meta),
+    ).to_node()
+
+    assert node.get_should_check_columns() is config_meta

--- a/dbt_dry_run/test/test_result_reporter.py
+++ b/dbt_dry_run/test/test_result_reporter.py
@@ -5,9 +5,9 @@ import pytest
 from dbt_dry_run.models import Table
 from dbt_dry_run.result_reporter import ResultReporter
 from dbt_dry_run.results import (
-    ColumnError,
     DryRunResult,
     DryRunStatus,
+    LintingError,
     LintingStatus,
     Results,
 )
@@ -44,7 +44,9 @@ def failed_linting_result() -> DryRunResult:
         status=DryRunStatus.SUCCESS,
         exception=None,
         linting_status=LintingStatus.FAILURE,
-        linting_errors=[ColumnError(rule="TEST_LINTING_RULE", message="Linting wrong")],
+        linting_errors=[
+            LintingError(rule="TEST_LINTING_RULE", message="Linting wrong")
+        ],
     )
 
 

--- a/dbt_dry_run/test/test_result_reporter.py
+++ b/dbt_dry_run/test/test_result_reporter.py
@@ -4,7 +4,13 @@ import pytest
 
 from dbt_dry_run.models import Table
 from dbt_dry_run.result_reporter import ResultReporter
-from dbt_dry_run.results import DryRunResult, DryRunStatus, Results
+from dbt_dry_run.results import (
+    ColumnError,
+    DryRunResult,
+    DryRunStatus,
+    LintingStatus,
+    Results,
+)
 from dbt_dry_run.test.utils import SimpleNode
 
 
@@ -15,6 +21,7 @@ def successful_result() -> DryRunResult:
         table=Table(fields=[]),
         status=DryRunStatus.SUCCESS,
         exception=None,
+        linting_status=LintingStatus.SKIPPED,
     )
 
 
@@ -25,6 +32,19 @@ def failed_result() -> DryRunResult:
         table=Table(fields=[]),
         status=DryRunStatus.FAILURE,
         exception=Exception("Oh no!"),
+        linting_status=LintingStatus.SKIPPED,
+    )
+
+
+@pytest.fixture()
+def failed_linting_result() -> DryRunResult:
+    return DryRunResult(
+        node=SimpleNode(unique_id="B", depends_on=[]).to_node(),
+        table=Table(fields=[]),
+        status=DryRunStatus.SUCCESS,
+        exception=None,
+        linting_status=LintingStatus.FAILURE,
+        linting_errors=[ColumnError(rule="TEST_LINTING_RULE", message="Linting wrong")],
     )
 
 
@@ -45,5 +65,13 @@ def test_failed_results(
     successful_result: DryRunResult, failed_result: DryRunResult
 ) -> None:
     failed_results = build_results([successful_result, failed_result])
+    reporter = ResultReporter(failed_results, set())
+    assert reporter.report_and_check_results() == 1
+
+
+def test_failed_linting_results(
+    successful_result: DryRunResult, failed_linting_result: DryRunResult
+) -> None:
+    failed_results = build_results([successful_result, failed_linting_result])
     reporter = ResultReporter(failed_results, set())
     assert reporter.report_and_check_results() == 1

--- a/dbt_dry_run/test/utils.py
+++ b/dbt_dry_run/test/utils.py
@@ -1,8 +1,8 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
-from dbt_dry_run.models.manifest import Node, NodeConfig, NodeDependsOn
+from dbt_dry_run.models.manifest import Node, NodeConfig, NodeDependsOn, NodeMeta
 from dbt_dry_run.scheduler import ManifestScheduler
 
 A_SQL_QUERY = "SELECT * FROM `foo`"
@@ -20,6 +20,7 @@ class SimpleNode(BaseModel):
     compiled_code: str = A_SQL_QUERY
     original_file_path: str = f"test123.sql"
     root_path: str = "/home/"
+    meta: Optional[NodeMeta]
 
     def to_node(self) -> Node:
         depends_on = NodeDependsOn(
@@ -40,6 +41,7 @@ class SimpleNode(BaseModel):
             original_file_path=self.original_file_path,
             root_path=self.root_path,
             columns=dict(),
+            meta=self.meta,
         )
 
 

--- a/dbt_dry_run/test/utils.py
+++ b/dbt_dry_run/test/utils.py
@@ -39,6 +39,7 @@ class SimpleNode(BaseModel):
             resource_type=resource_type,
             original_file_path=self.original_file_path,
             root_path=self.root_path,
+            columns=dict(),
         )
 
 

--- a/integration/projects/test_column_linting/dbt_project.yml
+++ b/integration/projects/test_column_linting/dbt_project.yml
@@ -25,3 +25,7 @@ models:
   test_column_linting:
     +enabled: true
     +materialized: view
+
+    sub_dir:
+      +meta:
+         dry_run.check_columns: true

--- a/integration/projects/test_column_linting/dbt_project.yml
+++ b/integration/projects/test_column_linting/dbt_project.yml
@@ -1,0 +1,27 @@
+name: 'test_column_linting'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+# This will get overridden by the root project
+profile: 'default'
+
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "logs"
+
+
+# Configuring models
+models:
+  # This should match your project name
+  test_column_linting:
+    +enabled: true
+    +materialized: view

--- a/integration/projects/test_column_linting/models/badly_documented_model.sql
+++ b/integration/projects/test_column_linting/models/badly_documented_model.sql
@@ -1,0 +1,4 @@
+{{ config(alias="badly_documented_model") }}
+
+SELECT *
+FROM (SELECT "a" as `a`, "b" as `b`, 1 as c)

--- a/integration/projects/test_column_linting/models/model_linting_disabled.sql
+++ b/integration/projects/test_column_linting/models/model_linting_disabled.sql
@@ -1,0 +1,4 @@
+{{ config(alias="linting_disabled") }}
+
+SELECT *
+FROM (SELECT "a" as `a`, "b" as `b`, 1 as c)

--- a/integration/projects/test_column_linting/models/model_linting_not_specified.sql
+++ b/integration/projects/test_column_linting/models/model_linting_not_specified.sql
@@ -1,0 +1,4 @@
+{{ config(alias="not_specified") }}
+
+SELECT *
+FROM (SELECT "a" as `a`, "b" as `b`, 1 as c)

--- a/integration/projects/test_column_linting/models/model_with_struct.sql
+++ b/integration/projects/test_column_linting/models/model_with_struct.sql
@@ -1,0 +1,4 @@
+{{ config(alias="model_with_struct") }}
+
+SELECT *
+FROM (SELECT "a" as `a`, STRUCT("s1" as s1, 2 as s2) as s)

--- a/integration/projects/test_column_linting/models/model_with_struct.sql
+++ b/integration/projects/test_column_linting/models/model_with_struct.sql
@@ -1,4 +1,7 @@
 {{ config(alias="model_with_struct") }}
 
 SELECT *
-FROM (SELECT "a" as `a`, STRUCT("s1" as s1, 2 as s2) as s)
+FROM (SELECT
+             "a" as `a`,
+             STRUCT("s1" as s1, 2 as s2, STRUCT("ss1" as ss1) as s3) as s
+    )

--- a/integration/projects/test_column_linting/models/models.yml
+++ b/integration/projects/test_column_linting/models/models.yml
@@ -31,3 +31,17 @@ models:
     columns:
       - name: a
         description: This is in the model
+
+  - name: model_with_struct
+    description: This model is correctly documented as a struct
+    meta:
+      dry_run.check_columns: true
+    columns:
+      - name: a
+        description: This is in the model
+
+      - name: s.s1
+        description: Struct field called s1
+
+      - name: s.s2
+        descipriont: Struct field called s2

--- a/integration/projects/test_column_linting/models/models.yml
+++ b/integration/projects/test_column_linting/models/models.yml
@@ -40,8 +40,17 @@ models:
       - name: a
         description: This is in the model
 
+      - name: s
+        description: Struct root
+
       - name: s.s1
         description: Struct field called s1
 
       - name: s.s2
         descipriont: Struct field called s2
+
+      - name: s.s3
+        description: Nested struct root
+
+      - name: s.s3.ss1
+        description: Nested field

--- a/integration/projects/test_column_linting/models/models.yml
+++ b/integration/projects/test_column_linting/models/models.yml
@@ -1,0 +1,33 @@
+version: 2
+
+models:
+  - name: badly_documented_model
+    description: This model is missing some columns in its docs
+    meta:
+      dry_run.check_columns: true
+    columns:
+      - name: a
+        description: This is in the model
+
+      - name: b
+        description: This is in the model
+
+#      - name: c
+#        description: Forgot to document c
+
+      - name: d
+        description: This shouldn't be here
+
+  - name: model_linting_disabled
+    description: This model is missing some columns in its docs, but should not error as linting is disabled
+    meta:
+      dry_run.check_columns: false
+    columns:
+      - name: a
+        description: This is in the model
+
+  - name: model_linting_not_specified
+    description: This model is missing some columns in its docs, but should not error as linting shouold be skipped
+    columns:
+      - name: a
+        description: This is in the model

--- a/integration/projects/test_column_linting/models/models.yml
+++ b/integration/projects/test_column_linting/models/models.yml
@@ -20,8 +20,8 @@ models:
 
   - name: model_linting_disabled
     description: This model is missing some columns in its docs, but should not error as linting is disabled
-    meta:
-      dry_run.check_columns: false
+#    meta:
+#      dry_run.check_columns: false
     columns:
       - name: a
         description: This is in the model

--- a/integration/projects/test_column_linting/models/sub_dir/badly_documented_model_in_sub_dir.sql
+++ b/integration/projects/test_column_linting/models/sub_dir/badly_documented_model_in_sub_dir.sql
@@ -1,0 +1,4 @@
+{{ config(alias="badly_documented_model_in_sub_dir") }}
+
+SELECT *
+FROM (SELECT "a" as `a`, "b" as `b`, 1 as colour)

--- a/integration/projects/test_column_linting/models/sub_dir/models.yml
+++ b/integration/projects/test_column_linting/models/sub_dir/models.yml
@@ -1,0 +1,18 @@
+version: 2
+
+models:
+  - name: badly_documented_model_in_sub_dir
+    description: This model is missing some columns in its docs
+    # Should inherit meta from dbt_project.yml
+    columns:
+      - name: a
+        description: This is in the model
+
+      - name: b
+        description: This is in the model
+
+#      - name: c
+#        description: Forgot to document c
+
+      - name: d
+        description: This shouldn't be here

--- a/integration/projects/test_column_linting/test_column_linting.py
+++ b/integration/projects/test_column_linting/test_column_linting.py
@@ -1,0 +1,29 @@
+from dbt_dry_run.results import LintingStatus
+from integration.conftest import IntegrationTestResult
+from integration.utils import get_report_node_by_id
+
+
+def test_linted_model_fails(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "model.test_column_linting.badly_documented_model")
+    expected_errors = {"Column not documented in metadata: 'c'", "Extra column in metadata: 'd'"}
+
+    assert node.linting_status == LintingStatus.FAILURE
+    assert len(node.linting_errors) == 2
+    assert set(map(lambda err: err.message, node.linting_errors)) == expected_errors
+
+
+def test_linting_disabled_model_skipped(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "model.test_column_linting.model_linting_disabled")
+
+    assert node.linting_status == LintingStatus.SKIPPED
+    assert len(node.linting_errors) == 0
+
+
+def test_linting_not_defined_model_skipped(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "model.test_column_linting.model_linting_not_specified")
+
+    assert node.linting_status == LintingStatus.SKIPPED
+    assert len(node.linting_errors) == 0

--- a/integration/projects/test_column_linting/test_column_linting.py
+++ b/integration/projects/test_column_linting/test_column_linting.py
@@ -33,3 +33,9 @@ def test_linting_model_with_structs_success(dry_run_result: IntegrationTestResul
     node = get_report_node_by_id(dry_run_result.report,
                                  "model.test_column_linting.model_with_struct")
     assert node.linting_status == LintingStatus.SUCCESS
+
+
+def test_linting_enabled_in_model_in_sub_dir(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "model.test_column_linting.badly_documented_model_in_sub_dir")
+    assert node.linting_status == LintingStatus.FAILURE

--- a/integration/projects/test_column_linting/test_column_linting.py
+++ b/integration/projects/test_column_linting/test_column_linting.py
@@ -27,3 +27,9 @@ def test_linting_not_defined_model_skipped(dry_run_result: IntegrationTestResult
 
     assert node.linting_status == LintingStatus.SKIPPED
     assert len(node.linting_errors) == 0
+
+
+def test_linting_model_with_structs_success(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "model.test_column_linting.model_with_struct")
+    assert node.linting_status == LintingStatus.SUCCESS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-dry-run"
-version = "0.4.2"
+version = "0.5.0"
 description = "Dry run dbt projects"
 authors = ["Connor Charles <connor.charles@autotrader.co.uk>",
            "Phil hope <philip.hope@autotrader.co.uk>",


### PR DESCRIPTION
# Description

This PR adds an experimental feature to 'lint' column metadata to ensure that it matches the predicted schema. See README changes for details.

Essentially if you specify that you want dry run linting you can validate in CI/CD/PR wether the models columns have been correctly documented on their predicted schema, not just on the schema existing in the warehouse.

# Readme explaining feature

### Column and Metadata Linting (Experimental!)

The dry runner can also be configured to inspect your metadata YAML and assert that the predicted schema of your dbt 
projects data warehouse matches what is documented in the metadata. To enable this for your models specify the key 
`dry_run.check_columns: true`. The dry runner will then fail if the model's documentation does not match. For example 
the full metadata for this model:

```yaml
models:
  - name: badly_documented_model
    description: This model is missing some columns in its docs
    meta:
      dry_run.check_columns: true
    columns:
      - name: a
        description: This is in the model
      - name: b
        description: This is in the model
#      - name: c
#        description: Forgot to document c
      - name: d
        description: This shouldn't be here
```

This model is badly documented as the predicted schema is 3 columns `a,b,c` the dry runner will therefore output the 
following error and fail your CI/CD checks:

```text
Dry running X models
Node model.test_column_linting.badly_documented_model failed linting with rule violations:
        UNDOCUMENTED_COLUMNS : Column not documented in metadata: 'c'
        EXTRA_DOCUMENTED_COLUMNS : Extra column in metadata: 'd'
Total 1 failures:
1       :       model.test_column_linting.badly_documented_model        :       LINTING :       ERROR
DRY RUN FAILURE!
```

Currently, these rules can cause linting failures:

1. UNDOCUMENTED_COLUMNS: The predicted schema of the model will have extra columns that have not been documented in the YAML
2. EXTRA_DOCUMENTED_COLUMNS: The predicted schema of the model does not have this column that was specified in the metadata

This could be extended to verify that datatype has been set correctly as well or other linting rules such as naming conventions 
based on datatype.

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
