### PR TITLE
Support dry running external sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+# dbt-dry-run v0.6.x
+
+## Improvements & Bugfixes
+
+- Added support for `dbt-external-tables`. Any `source` marked with `external` will be 'dry runned' by reading the 
+  schema from the yaml metdata for the source. The dry run does not support schema prediction for external tables
+
 # dbt-dry-run v0.5.1
 
 ## Bugfixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dbt-dry-run
 
-[dbt][dbt-home] is a tool that helps manage data transformations using templated SQL queries. These SQL queries are 
+[dbt][dbt-home] is a tool that helps manage data transformations using templated SQL queries. These SQL queries are
 executed against a target data warehouse. It doesn't check the validity of SQL queries before it executes your project.
 This dry runner uses BigQuery's [dry run][bq-dry-run] capability to allow you to check that SQL queries are valid before
 trying to execute them.
@@ -21,18 +21,18 @@ pip install dbt-dry-run
 
 ### Running
 
-The dry runner has a single command called `dbt-dry-run` in order for it to run you must 
-first compile a dbt manifest using `dbt compile` as you normally would.
+The dry runner has a single command called `dbt-dry-run` in order for it to run you must first compile a dbt manifest
+using `dbt compile` as you normally would.
 
-Then on the same machine (So that the dry runner has access to your dbt project source and the 
+Then on the same machine (So that the dry runner has access to your dbt project source and the
 `manifest.yml`) you can run the dry-runner in the same directory as our `dbt_project.yml`:
 
 ```
 dbt-dry-run
 ```
 
-Like dbt it will search for `profiles.yml` in `~/.dbt/` and use the default target specified.
-Just like in the dbt CLI you can override these defaults:
+Like dbt it will search for `profiles.yml` in `~/.dbt/` and use the default target specified. Just like in the dbt CLI
+you can override these defaults:
 
 ```
 dbt-dry-run default --project-dir /my_org_dbt/ --profiles-dir /my_org_dbt/profiles/ --target local
@@ -65,8 +65,7 @@ The full CLI help is shown below, anything prefixed with [dbt] can be used in th
 
 ## Reporting Results & Failures
 
-If the result is successful it will output the number of 
-models that were tested like so:
+If the result is successful it will output the number of models that were tested like so:
 
 ```
 Dry running 3 models
@@ -94,9 +93,9 @@ The process will also return exit code 1
 
 ### Column and Metadata Linting (Experimental!)
 
-The dry runner can also be configured to inspect your metadata YAML and assert that the predicted schema of your dbt 
-projects data warehouse matches what is documented in the metadata. To enable this for your models specify the key 
-`dry_run.check_columns: true`. The dry runner will then fail if the model's documentation does not match. For example 
+The dry runner can also be configured to inspect your metadata YAML and assert that the predicted schema of your dbt
+projects data warehouse matches what is documented in the metadata. To enable this for your models specify the key
+`dry_run.check_columns: true`. The dry runner will then fail if the model's documentation does not match. For example
 the full metadata for this model:
 
 ```yaml
@@ -112,14 +111,14 @@ models:
       - name: b
         description: This is in the model
 
-#      - name: c
-#        description: Forgot to document c
+      #      - name: c
+      #        description: Forgot to document c
 
       - name: d
         description: This shouldn't be here
 ```
 
-This model is badly documented as the predicted schema is 3 columns `a,b,c` the dry runner will therefore output the 
+This model is badly documented as the predicted schema is 3 columns `a,b,c` the dry runner will therefore output the
 following error and fail your CI/CD checks:
 
 ```text
@@ -135,15 +134,54 @@ DRY RUN FAILURE!
 
 Currently, these rules can cause linting failures:
 
-1. UNDOCUMENTED_COLUMNS: The predicted schema of the model will have extra columns that have not been documented in the YAML
-2. EXTRA_DOCUMENTED_COLUMNS: The predicted schema of the model does not have this column that was specified in the metadata
+1. UNDOCUMENTED_COLUMNS: The predicted schema of the model will have extra columns that have not been documented in the
+   YAML
+2. EXTRA_DOCUMENTED_COLUMNS: The predicted schema of the model does not have this column that was specified in the
+   metadata
 
-This could be extended to verify that datatype has been set correctly as well or other linting rules such as naming conventions 
-based on datatype.
+This could be extended to verify that datatype has been set correctly as well or other linting rules such as naming
+conventions based on datatype.
+
+### Usage with dbt-external-tables
+
+The dbt package [dbt-external-tables][dbt-external-tables] gives dbt support for staging and managing
+[external tables][bq-external-tables]. These sources do not produce any compiled sql in the manifest, so it is not
+possible for the dry runner to predict their schema. Therefore, you must specify the resulting schema manually in the
+metadata of the source. For example if you were import data from a gcs bucket:
+
+```yaml
+version: 2
+
+sources:
+  - name: source_dataset
+    tables:
+      - name: event
+        description: "Some events bucket. If external is populated then the dry runner will assume it is using `dbt-external-tables`"
+        external:
+          location: 'gs://bucket/path/*'
+            format: csv
+
+        columns:
+          - name: string_field
+            data_type: STRING
+            description: "Specify each column in the yaml for external sources"
+          - name: record_array_field[]
+            data_type: RECORD[]
+            description: "For struct/record fields specify the `data_type` as `RECORD`"
+          - name: record_array_field.foo
+            data_type: NUMERIC
+            description: "For record attributes use the dot notation"
+          - name: integer_array
+            data_type: NUMERIC[]
+            description: "For repeated fields suffix data_type with []"
+```
+
+The dry runner cannot predict the schema, therefore, it is up to you to accurately describe the schema in the YAML otherwise 
+you may get false positive/negative results from the dry run.
 
 ### Report Artefact
 
-If you specify `---report-path` a JSON file will be outputted regardless of dry run success/failure with detailed 
+If you specify `---report-path` a JSON file will be outputted regardless of dry run success/failure with detailed
 information of each node's predicted schema or error message if it has failed:
 
 ```json
@@ -161,7 +199,7 @@ information of each node's predicted schema or error message if it has failed:
       "error_message": null,
       "table": {
         "fields": [
-...
+          ...
         ]
       }
     },
@@ -171,7 +209,7 @@ information of each node's predicted schema or error message if it has failed:
       "error_message": null,
       "table": {
         "fields": [
-...
+          ...
         ]
       }
     },
@@ -198,11 +236,12 @@ Where `<PROJECT_DIR>` is one of the directory names in `/integration/projects/`.
 
 ### Running Integration Tests
 
-In order to run integration tests locally you will need access to a BigQuery project/instance in which your gcloud application 
-default credentials has the role `Big Query Data Owner`. The BigQuery instance should have an empty dataset called `dry_run`.
+In order to run integration tests locally you will need access to a BigQuery project/instance in which your gcloud
+application default credentials has the role `Big Query Data Owner`. The BigQuery instance should have an empty dataset
+called `dry_run`.
 
-Setting the environment variable `DBT_PROJECT=<YOUR GCP PROJECT HERE>` will tell the integration tests which GCP 
-project to run the test suite against. The test suite does not currently materialize any data into the project.
+Setting the environment variable `DBT_PROJECT=<YOUR GCP PROJECT HERE>` will tell the integration tests which GCP project
+to run the test suite against. The test suite does not currently materialize any data into the project.
 
 The integration tests will run on any push to `main` to ensure the package's core functionality is still in place.
 
@@ -212,26 +251,23 @@ __Auto Trader employees can request authorisation to access the `at-dry-run-inte
 
 ### Things this can catch
 
-The dry run can catch anything the BigQuery planner can identify before the query has run. Which 
-includes:
+The dry run can catch anything the BigQuery planner can identify before the query has run. Which includes:
 
 1. Typos in SQL keywords:  `selec` instead of `select`
 2. Typos in columns names: `orders.produts` instead of `orders.products`
 3. Problems with incompatible data types: Trying to execute "4" + 4
-4. Incompatible schema changes to models: Removing a column from a view that is referenced
-by a downstream model explicitly
-5. Incompatible schema changes to sources: Third party modifies schema of source tables without 
-your knowledge
-6. Permission errors: The dry runner should run under the same service account your production 
-job runs under. This allows you to catch problems with table/project permissions as dry run queries
-need table read permissions just like the real query
-7. Incorrect configuration of snapshots: For example a typo in the `unique_key` config. Or `check_cols` which do not 
-exist in the snapshot
-   
+4. Incompatible schema changes to models: Removing a column from a view that is referenced by a downstream model
+   explicitly
+5. Incompatible schema changes to sources: Third party modifies schema of source tables without your knowledge
+6. Permission errors: The dry runner should run under the same service account your production job runs under. This
+   allows you to catch problems with table/project permissions as dry run queries need table read permissions just like
+   the real query
+7. Incorrect configuration of snapshots: For example a typo in the `unique_key` config. Or `check_cols` which do not
+   exist in the snapshot
+
 ### Things this can't catch
 
-There are certain cases where a syntactically valid query can fail due to the data in 
-the tables:
+There are certain cases where a syntactically valid query can fail due to the data in the tables:
 
 1. Queries that run but do not return intended/correct result. This is checked using [tests][dbt-tests]
 2. `NULL` values in `ARRAY_AGG` (See [IGNORE_NULLS bullet point][bq-ignore-nulls])
@@ -239,34 +275,38 @@ the tables:
 
 ### Things still to do...
 
-Implementing the dry runner required re-implementing some areas of dbt. Mainly how the 
-adapter sets up connections and credentials with the BigQuery client, we have only 
-implemented the methods of how we connect to our warehouse so if you don't use OAUTH or 
-service account JSON files then this won't be able to read `profiles.yml` correctly.
+Implementing the dry runner required re-implementing some areas of dbt. Mainly how the adapter sets up connections and
+credentials with the BigQuery client, we have only implemented the methods of how we connect to our warehouse so if you
+don't use OAUTH or service account JSON files then this won't be able to read `profiles.yml` correctly.
 
-The implementation of seeds is incomplete as well as we don't use them very much in our 
-own dbt projects. The dry runner will just use the datatypes that `agate` infers from the CSV 
-files.
+The implementation of seeds is incomplete as well as we don't use them very much in our own dbt projects. The dry runner
+will just use the datatypes that `agate` infers from the CSV files.
 
 [dbt-home]: https://www.getdbt.com/
+
 [bq-dry-run]: https://cloud.google.com/bigquery/docs/dry-run-queries
+
 [dbt-tests]: https://docs.getdbt.com/docs/building-a-dbt-project/tests
+
 [bq-ignore-nulls]: https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#array_agg
+
 [blog-post]: https://engineering.autotrader.co.uk/2022/04/06/dry-running-our-data-warehouse-using-bigquery-and-dbt.html
+
 [get-poetry]: https://python-poetry.org/
+
+[dbt-external-tables]: https://github.com/dbt-labs/dbt-external-tables
+
+[bq-external-tables]: https://cloud.google.com/bigquery/docs/external-tables
 
 ## License
 
 Copyright 2022 Auto Trader Limited
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "
+AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.

--- a/dbt_dry_run/columns_metadata.py
+++ b/dbt_dry_run/columns_metadata.py
@@ -1,0 +1,98 @@
+from itertools import groupby
+from typing import Dict, List, Set, Tuple
+
+from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, Table, TableField
+from dbt_dry_run.models.manifest import ManifestColumn
+
+REPEATED_SUFFIX = "[]"
+STRUCT_SEPERATOR = "."
+STRUCT_SEPERATOR_LENGTH = len(STRUCT_SEPERATOR)
+
+
+def _extract_fields(table_fields: List[TableField], prefix: str = "") -> List[str]:
+    field_names = []
+    for field in table_fields:
+        field_names.append(f"{prefix}{field.name}")
+        if field.fields:
+            new_prefix = f"{prefix}{field.name}."
+            field_names.extend(_extract_fields(field.fields, prefix=new_prefix))
+    return field_names
+
+
+def expand_table_fields(table: Table) -> Set[str]:
+    """
+    Expand table fields to dot notation (like in dbt metadata)
+
+    Eg: TableField(name="a", fields=[TableField(name="a1")])
+    Returns: ["a", "a.a1"]
+    """
+    return set(_extract_fields(table.fields))
+
+
+def _column_is_repeated(data_type: str) -> bool:
+    return data_type.endswith(REPEATED_SUFFIX)
+
+
+def _split_column_data_type_and_mode(
+    data_type: str,
+) -> Tuple[BigQueryFieldType, BigQueryFieldMode]:
+    mode = (
+        BigQueryFieldMode.REPEATED
+        if _column_is_repeated(data_type)
+        else BigQueryFieldMode.NULLABLE
+    )
+    if mode == BigQueryFieldMode.REPEATED:
+        clean_data_type = data_type[: -len(REPEATED_SUFFIX)]
+    else:
+        clean_data_type = data_type
+    return BigQueryFieldType(clean_data_type), mode
+
+
+def _get_sub_field_map(
+    cols: Dict[str, ManifestColumn], sub_field_columns: List[str], root_name: str
+) -> Dict[str, ManifestColumn]:
+    root_prefix_size = len(root_name) + STRUCT_SEPERATOR_LENGTH
+    sub_field_names = list(
+        map(
+            lambda col: col[root_prefix_size:],
+            sub_field_columns[1:],
+        )
+    )
+    sub_field_map = {
+        col: cols[root_name + STRUCT_SEPERATOR + col] for col in sub_field_names
+    }
+    return sub_field_map
+
+
+def _to_fields(cols: Dict[str, ManifestColumn]) -> List[TableField]:
+    sorted_columns = sorted(cols.keys())
+    grouped_columns = groupby(
+        sorted_columns, lambda val: val.split(STRUCT_SEPERATOR)[0]
+    )
+    fields = {}
+    for root_name, group_cols_iterator in grouped_columns:
+        group_cols = list(group_cols_iterator)
+        if group_cols[0] != root_name:
+            raise ValueError(
+                f"Could not find root record '{root_name}' for struct fields in metadata '{group_cols}'"
+            )
+        column = cols[root_name]
+        if not column.data_type:
+            raise ValueError(
+                f"Can't determine schema of column '{root_name}' without 'data_type' in metadata"
+            )
+        sub_field_map = _get_sub_field_map(cols, group_cols, root_name)
+        if sub_field_map:
+            sub_fields = _to_fields(sub_field_map)
+        else:
+            sub_fields = None
+        field_data_type, field_mode = _split_column_data_type_and_mode(column.data_type)
+        fields[root_name] = TableField(
+            name=root_name, type=field_data_type, mode=field_mode, fields=sub_fields
+        )
+
+    return list(fields.values())
+
+
+def map_columns_to_table(columns: Dict[str, ManifestColumn]) -> Table:
+    return Table(fields=_to_fields(columns))

--- a/dbt_dry_run/columns_metadata.py
+++ b/dbt_dry_run/columns_metadata.py
@@ -1,7 +1,7 @@
 from itertools import groupby
 from typing import Dict, List, Set, Tuple
 
-from dbt_dry_run.exception import UnknownDataTypeException, InvalidColumnSpecification
+from dbt_dry_run.exception import InvalidColumnSpecification, UnknownDataTypeException
 from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, Table, TableField
 from dbt_dry_run.models.manifest import ManifestColumn
 
@@ -50,7 +50,9 @@ def _split_column_data_type_and_mode(
     try:
         return BigQueryFieldType(clean_data_type), mode
     except ValueError:
-        raise UnknownDataTypeException(f"Could not parse data_type `{clean_data_type}` from manifest")
+        raise UnknownDataTypeException(
+            f"Could not parse data_type `{clean_data_type}` from manifest"
+        )
 
 
 def _get_sub_field_map(

--- a/dbt_dry_run/columns_metadata.py
+++ b/dbt_dry_run/columns_metadata.py
@@ -72,6 +72,10 @@ def _get_sub_field_map(
 
 
 def _to_fields(cols: Dict[str, ManifestColumn]) -> List[TableField]:
+    if not cols:
+        raise InvalidColumnSpecification(
+            "Schema not specified in `columns` attribute in metadata"
+        )
     sorted_columns = sorted(cols.keys())
     grouped_columns = groupby(
         sorted_columns, lambda val: val.split(STRUCT_SEPERATOR)[0]

--- a/dbt_dry_run/exception.py
+++ b/dbt_dry_run/exception.py
@@ -6,6 +6,10 @@ class UpstreamFailedException(Exception):
     pass
 
 
+class SourceMissingException(Exception):
+    pass
+
+
 class NodeExecutionException(Exception):
     pass
 

--- a/dbt_dry_run/exception.py
+++ b/dbt_dry_run/exception.py
@@ -10,6 +10,14 @@ class SourceMissingException(Exception):
     pass
 
 
+class InvalidColumnSpecification(Exception):
+    pass
+
+
+class UnknownDataTypeException(Exception):
+    pass
+
+
 class NodeExecutionException(Exception):
     pass
 

--- a/dbt_dry_run/execution.py
+++ b/dbt_dry_run/execution.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple
 from dbt_dry_run.adapter.service import ProjectService
 from dbt_dry_run.linting.column_linting import lint_columns
 from dbt_dry_run.node_runner.snapshot_runner import SnapshotRunner
+from dbt_dry_run.node_runner.source_runner import SourceRunner
 from dbt_dry_run.sql_runner import SQLRunner
 
 if TYPE_CHECKING:
@@ -28,7 +29,7 @@ from dbt_dry_run.sql_runner.big_query_sql_runner import BigQuerySQLRunner
 
 CONCURRENCY = 8
 
-_RUNNER_CLASSES: List[Any] = [ModelRunner, SeedRunner, SnapshotRunner]
+_RUNNER_CLASSES: List[Any] = [ModelRunner, SeedRunner, SnapshotRunner, SourceRunner]
 _RUNNERS = get_runner_map(_RUNNER_CLASSES)
 
 
@@ -44,7 +45,7 @@ def dry_run_node(runners: Dict[str, NodeRunner], node: Node, results: Results) -
     """
     This method must be thread safe
     """
-    if node.compiled:
+    if node.compiled or node.is_external_source():
         dry_run_result = dispatch_node(node, runners)
         if node.get_should_check_columns():
             dry_run_result = lint_columns(node, dry_run_result)

--- a/dbt_dry_run/linting/column_linting.py
+++ b/dbt_dry_run/linting/column_linting.py
@@ -1,28 +1,9 @@
-from typing import Callable, Dict, List, Set
+from typing import Callable, Dict, List
 
-from dbt_dry_run.models import Table, TableField
+from dbt_dry_run.columns_metadata import expand_table_fields
+from dbt_dry_run.models import Table
 from dbt_dry_run.models.manifest import ManifestColumn, Node
 from dbt_dry_run.results import DryRunResult, LintingError
-
-
-def _extract_fields(table_fields: List[TableField], prefix: str = "") -> List[str]:
-    field_names = []
-    for field in table_fields:
-        field_names.append(f"{prefix}{field.name}")
-        if field.fields:
-            new_prefix = f"{prefix}{field.name}."
-            field_names.extend(_extract_fields(field.fields, prefix=new_prefix))
-    return field_names
-
-
-def expand_table_fields(table: Table) -> Set[str]:
-    """
-    Expand table fields to dot notation (like in dbt metadata)
-
-    Eg: TableField(name="a", fields=[TableField(name="a1")])
-    Returns: ["a", "a.a1"]
-    """
-    return set(_extract_fields(table.fields))
 
 
 def get_extra_documented_columns(

--- a/dbt_dry_run/node_runner/source_runner.py
+++ b/dbt_dry_run/node_runner/source_runner.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from dbt_dry_run.columns_metadata import map_columns_to_table
+from dbt_dry_run.exception import SourceMissingException
+from dbt_dry_run.models import Table
+from dbt_dry_run.models.manifest import Node
+from dbt_dry_run.node_runner import NodeRunner
+from dbt_dry_run.results import DryRunResult, DryRunStatus
+
+
+class SourceRunner(NodeRunner):
+    resource_type = ("source",)
+
+    def run(self, node: Node) -> DryRunResult:
+        exception: Optional[Exception] = None
+        predicted_table: Optional[Table] = None
+        status = DryRunStatus.SUCCESS
+        if node.is_external_source():
+            try:
+                predicted_table = map_columns_to_table(node.columns)
+            except ValueError as e:
+                status = DryRunStatus.FAILURE
+                exception = e
+        else:
+            if not self._sql_runner.node_exists(node):
+                status = DryRunStatus.FAILURE
+                exception = SourceMissingException(
+                    f"Could not find source in target environment for node '{node.unique_id}'"
+                )
+
+        return DryRunResult(node, predicted_table, status, exception)

--- a/dbt_dry_run/node_runner/source_runner.py
+++ b/dbt_dry_run/node_runner/source_runner.py
@@ -1,7 +1,11 @@
 from typing import Optional
 
 from dbt_dry_run.columns_metadata import map_columns_to_table
-from dbt_dry_run.exception import SourceMissingException
+from dbt_dry_run.exception import (
+    InvalidColumnSpecification,
+    SourceMissingException,
+    UnknownDataTypeException,
+)
 from dbt_dry_run.models import Table
 from dbt_dry_run.models.manifest import Node
 from dbt_dry_run.node_runner import NodeRunner
@@ -18,7 +22,7 @@ class SourceRunner(NodeRunner):
         if node.is_external_source():
             try:
                 predicted_table = map_columns_to_table(node.columns)
-            except ValueError as e:
+            except (InvalidColumnSpecification, UnknownDataTypeException) as e:
                 status = DryRunStatus.FAILURE
                 exception = e
         else:

--- a/dbt_dry_run/result_reporter.py
+++ b/dbt_dry_run/result_reporter.py
@@ -119,7 +119,7 @@ class ResultReporter:
         error_message = str(exception)
         if not self._verbose:
             query_job_slq_position = error_message.find(QUERY_JOB_SQL_FOLLOWS)
-            if query_job_slq_position:
+            if query_job_slq_position >= 0:
                 error_message = error_message[:query_job_slq_position].strip()
         else:
             error_message = QUERY_JOB_HEADER.sub(error_message, "")

--- a/dbt_dry_run/scheduler.py
+++ b/dbt_dry_run/scheduler.py
@@ -12,7 +12,7 @@ class ManifestScheduler:
     SNAPSHOT = "snapshot"
     SOURCE = "source"
     RUNNABLE_RESOURCE_TYPE = (MODEL, SEED, SNAPSHOT, SOURCE)
-    RUNNABLE_MATERIAL = ("view", "table", "incremental", "seed", "snapshot", "source")
+    RUNNABLE_MATERIAL = ("view", "table", "incremental", "seed", "snapshot")
 
     def __init__(self, manifest: Manifest, model: Optional[str] = None):
         self._manifest = manifest

--- a/dbt_dry_run/test/linting/test_column_linting.py
+++ b/dbt_dry_run/test/linting/test_column_linting.py
@@ -1,63 +1,12 @@
-from typing import List, Optional
+from typing import List
 
 from dbt_dry_run.linting.column_linting import (
-    expand_table_fields,
     get_extra_documented_columns,
     get_undocumented_columns,
 )
-from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, Table, TableField
+from dbt_dry_run.models import Table
 from dbt_dry_run.models.manifest import ManifestColumn
-
-
-def field_with_name(
-    name: str,
-    type_: BigQueryFieldType = BigQueryFieldType.STRING,
-    mode: BigQueryFieldMode = BigQueryFieldMode.NULLABLE,
-    fields: Optional[List[TableField]] = None,
-) -> TableField:
-    return TableField(name=name, type=type_, mode=mode, fields=fields)
-
-
-def test_expand_table_fields_with_column_names_with_no_nesting() -> None:
-    table = Table(fields=[field_with_name("a"), field_with_name("b")])
-
-    expected = {"a", "b"}
-    actual = expand_table_fields(table)
-    assert actual == expected
-
-
-def test_expand_table_fields_with_struct() -> None:
-    table = Table(
-        fields=[
-            field_with_name("a"),
-            field_with_name(
-                "struct",
-                fields=[field_with_name("struct_1"), field_with_name("struct_2")],
-            ),
-        ]
-    )
-
-    expected = {"a", "struct", "struct.struct_1", "struct.struct_2"}
-    actual = expand_table_fields(table)
-    assert actual == expected
-
-
-def test_expand_table_fields_with_nested_struct() -> None:
-    table = Table(
-        fields=[
-            field_with_name("a"),
-            field_with_name(
-                "struct",
-                fields=[
-                    field_with_name("struct_1", fields=[field_with_name("struct_1_1")])
-                ],
-            ),
-        ]
-    )
-
-    expected = {"a", "struct", "struct.struct_1", "struct.struct_1.struct_1_1"}
-    actual = expand_table_fields(table)
-    assert actual == expected
+from dbt_dry_run.test.utils import field_with_name
 
 
 def test_get_extra_documented_columns_passes_if_no_extra_columns() -> None:

--- a/dbt_dry_run/test/test_columns_metadata.py
+++ b/dbt_dry_run/test/test_columns_metadata.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 import pytest
 
 from dbt_dry_run.columns_metadata import REPEATED_SUFFIX, map_columns_to_table
-from dbt_dry_run.exception import UnknownDataTypeException, InvalidColumnSpecification
+from dbt_dry_run.exception import InvalidColumnSpecification, UnknownDataTypeException
 from dbt_dry_run.literals import enable_test_example_values
 from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, Table, TableField
 from dbt_dry_run.models.manifest import ManifestColumn
@@ -16,11 +16,11 @@ def get_column_map(columns: List[ManifestColumn]) -> Dict[str, ManifestColumn]:
 
 
 def assert_columns_result_in_table(
-        columns: List[ManifestColumn], expected: Table
+    columns: List[ManifestColumn], expected: Table
 ) -> None:
     actual = map_columns_to_table(get_column_map(columns))
     assert (
-            actual == expected
+        actual == expected
     ), f"SQL Literal:\n {actual} does not equal expected:\n {expected}"
 
 

--- a/dbt_dry_run/test/test_columns_metadata.py
+++ b/dbt_dry_run/test/test_columns_metadata.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 import pytest
 
 from dbt_dry_run.columns_metadata import REPEATED_SUFFIX, map_columns_to_table
+from dbt_dry_run.exception import UnknownDataTypeException, InvalidColumnSpecification
 from dbt_dry_run.literals import enable_test_example_values
 from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, Table, TableField
 from dbt_dry_run.models.manifest import ManifestColumn
@@ -15,11 +16,11 @@ def get_column_map(columns: List[ManifestColumn]) -> Dict[str, ManifestColumn]:
 
 
 def assert_columns_result_in_table(
-    columns: List[ManifestColumn], expected: Table
+        columns: List[ManifestColumn], expected: Table
 ) -> None:
     actual = map_columns_to_table(get_column_map(columns))
     assert (
-        actual == expected
+            actual == expected
     ), f"SQL Literal:\n {actual} does not equal expected:\n {expected}"
 
 
@@ -103,11 +104,20 @@ def test_map_columns_to_table_handles_record() -> None:
     assert_columns_result_in_table(columns, table)
 
 
+def test_map_columns_to_table_raises_error_when_using_unknown_data_type() -> None:
+    columns = [
+        ManifestColumn(name="a", data_type=BigQueryFieldType.STRING + "_WRONG"),
+        ManifestColumn(name="b", data_type=BigQueryFieldType.STRING),
+    ]
+    with pytest.raises(UnknownDataTypeException):
+        map_columns_to_table(get_column_map(columns))
+
+
 def test_map_columns_to_table_raises_error_when_struct_root_not_defined() -> None:
     columns = [
         ManifestColumn(name="a", data_type=BigQueryFieldType.STRING),
         ManifestColumn(name="b.c", data_type=BigQueryFieldType.STRING),
         ManifestColumn(name="b.d", data_type=BigQueryFieldType.NUMERIC),
     ]
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidColumnSpecification):
         map_columns_to_table(get_column_map(columns))

--- a/dbt_dry_run/test/test_columns_metadata.py
+++ b/dbt_dry_run/test/test_columns_metadata.py
@@ -1,0 +1,113 @@
+from typing import Dict, List
+
+import pytest
+
+from dbt_dry_run.columns_metadata import REPEATED_SUFFIX, map_columns_to_table
+from dbt_dry_run.literals import enable_test_example_values
+from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, Table, TableField
+from dbt_dry_run.models.manifest import ManifestColumn
+
+enable_test_example_values(True)
+
+
+def get_column_map(columns: List[ManifestColumn]) -> Dict[str, ManifestColumn]:
+    return {col.name: col for col in columns}
+
+
+def assert_columns_result_in_table(
+    columns: List[ManifestColumn], expected: Table
+) -> None:
+    actual = map_columns_to_table(get_column_map(columns))
+    assert (
+        actual == expected
+    ), f"SQL Literal:\n {actual} does not equal expected:\n {expected}"
+
+
+def field_type_as_repeated(field_type: BigQueryFieldType) -> str:
+    return field_type + REPEATED_SUFFIX
+
+
+def test_map_columns_to_table_handles_flat_schema() -> None:
+    columns = [
+        ManifestColumn(name="a", data_type=BigQueryFieldType.STRING),
+        ManifestColumn(name="b", data_type=BigQueryFieldType.NUMERIC),
+    ]
+    table = Table(
+        fields=[
+            TableField(
+                name="a", type=BigQueryFieldType.STRING, mode=BigQueryFieldMode.NULLABLE
+            ),
+            TableField(
+                name="b",
+                type=BigQueryFieldType.NUMERIC,
+                mode=BigQueryFieldMode.NULLABLE,
+            ),
+        ]
+    )
+    assert_columns_result_in_table(columns, table)
+
+
+def test_map_columns_to_table_handles_repeated_fields() -> None:
+    columns = [
+        ManifestColumn(name="a", data_type=BigQueryFieldType.STRING),
+        ManifestColumn(
+            name="b", data_type=field_type_as_repeated(BigQueryFieldType.NUMERIC)
+        ),
+    ]
+    table = Table(
+        fields=[
+            TableField(
+                name="a", type=BigQueryFieldType.STRING, mode=BigQueryFieldMode.NULLABLE
+            ),
+            TableField(
+                name="b",
+                type=BigQueryFieldType.NUMERIC,
+                mode=BigQueryFieldMode.REPEATED,
+            ),
+        ]
+    )
+    assert_columns_result_in_table(columns, table)
+
+
+def test_map_columns_to_table_handles_record() -> None:
+    columns = [
+        ManifestColumn(name="a", data_type=BigQueryFieldType.STRING),
+        ManifestColumn(name="b", data_type=BigQueryFieldType.RECORD),
+        ManifestColumn(name="b.c", data_type=BigQueryFieldType.STRING),
+        ManifestColumn(name="b.d", data_type=BigQueryFieldType.NUMERIC),
+    ]
+    table = Table(
+        fields=[
+            TableField(
+                name="a", type=BigQueryFieldType.STRING, mode=BigQueryFieldMode.NULLABLE
+            ),
+            TableField(
+                name="b",
+                type=BigQueryFieldType.RECORD,
+                mode=BigQueryFieldMode.NULLABLE,
+                fields=[
+                    TableField(
+                        name="c",
+                        type=BigQueryFieldType.STRING,
+                        mode=BigQueryFieldMode.NULLABLE,
+                    ),
+                    TableField(
+                        name="d",
+                        type=BigQueryFieldType.NUMERIC,
+                        mode=BigQueryFieldMode.NULLABLE,
+                    ),
+                ],
+            ),
+        ]
+    )
+    assert_columns_result_in_table(columns, table)
+
+
+def test_map_columns_to_table_raises_error_when_struct_root_not_defined() -> None:
+    columns = [
+        ManifestColumn(name="a", data_type=BigQueryFieldType.STRING),
+        ManifestColumn(name="b.c", data_type=BigQueryFieldType.STRING),
+        ManifestColumn(name="b.d", data_type=BigQueryFieldType.NUMERIC),
+    ]
+    with pytest.raises(ValueError):
+        map_columns_to_table(get_column_map(columns))

--- a/dbt_dry_run/test/utils.py
+++ b/dbt_dry_run/test/utils.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -10,7 +10,7 @@ A_SQL_QUERY = "SELECT * FROM `foo`"
 
 class SimpleNode(BaseModel):
     unique_id: str
-    depends_on: List["SimpleNode"]
+    depends_on: List[Union["SimpleNode", Node]]
     resource_type: str = ManifestScheduler.MODEL
     table_config: NodeConfig = NodeConfig(
         materialized="table", on_schema_change="ignore"

--- a/dbt_dry_run/test/utils.py
+++ b/dbt_dry_run/test/utils.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
+from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, TableField
 from dbt_dry_run.models.manifest import Node, NodeConfig, NodeDependsOn, NodeMeta
 from dbt_dry_run.scheduler import ManifestScheduler
 
@@ -46,3 +47,12 @@ class SimpleNode(BaseModel):
 
 
 SimpleNode.update_forward_refs()
+
+
+def field_with_name(
+    name: str,
+    type_: BigQueryFieldType = BigQueryFieldType.STRING,
+    mode: BigQueryFieldMode = BigQueryFieldMode.NULLABLE,
+    fields: Optional[List[TableField]] = None,
+) -> TableField:
+    return TableField(name=name, type=type_, mode=mode, fields=fields)

--- a/integration/projects/test_project_with_external_tables/dbt_project.yml
+++ b/integration/projects/test_project_with_external_tables/dbt_project.yml
@@ -1,0 +1,27 @@
+name: 'test_project_with_external_tables'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+# This will get overridden by the root project
+profile: 'default'
+
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "logs"
+
+
+# Configuring models
+models:
+  # This should match your project name
+  test_project_with_external_tables:
+    +enabled: true
+    +materialized: view

--- a/integration/projects/test_project_with_external_tables/models/first_layer.sql
+++ b/integration/projects/test_project_with_external_tables/models/first_layer.sql
@@ -1,0 +1,4 @@
+{{ config(alias="first_layer") }}
+
+SELECT *
+FROM {{ source("external", "src_external1") }}

--- a/integration/projects/test_project_with_external_tables/models/models.yml
+++ b/integration/projects/test_project_with_external_tables/models/models.yml
@@ -1,0 +1,22 @@
+version: 2
+
+sources:
+  - name: external
+    tables:
+      - name: src_external1
+        external:
+          location: this is still a required property, but it will be ignored
+
+        columns:
+          - name: rowkey
+            data_type: STRING
+          - name: events
+            data_type: RECORD[]
+          - name: events.column
+            data_type: RECORD[]
+          - name: events.column.name
+            data_type: STRING
+          - name: events.column.cell
+            data_type: RECORD[]
+          - name: events.column.cell.value
+            data_type: STRING

--- a/integration/projects/test_project_with_external_tables/models/models.yml
+++ b/integration/projects/test_project_with_external_tables/models/models.yml
@@ -20,3 +20,7 @@ sources:
             data_type: RECORD[]
           - name: events.column.cell.value
             data_type: STRING
+
+      - name: src_external_no_schema
+        external:
+          location: this is still a required property, but it will be ignored

--- a/integration/projects/test_project_with_external_tables/test_project_with_external_tables.py
+++ b/integration/projects/test_project_with_external_tables/test_project_with_external_tables.py
@@ -1,6 +1,6 @@
 from dbt_dry_run.node_runner.snapshot_runner import DBT_SNAPSHOT_FIELDS
 from integration.conftest import IntegrationTestResult
-from integration.utils import get_report_node_by_id, assert_report_node_has_columns
+from integration.utils import get_report_node_by_id, assert_report_node_has_columns, assert_node_failed_with_error
 
 DBT_SNAPSHOT_COLUMN_NAMES = set([field.name for field in DBT_SNAPSHOT_FIELDS])
 
@@ -11,3 +11,8 @@ def test_model_selecting_from_external_table_has_correct_schema(dry_run_result: 
     assert node.success
     assert_report_node_has_columns(node, {"rowkey", "events", "events.column", "events.column.name",
                                           "events.column.cell", "events.column.cell.value"})
+
+
+def test_model_selecting_from_external_table_raises_error_if_no_columns(dry_run_result: IntegrationTestResult):
+    assert_node_failed_with_error(dry_run_result.report,
+                                  "source.test_project_with_external_tables.external.src_external_no_schema", "InvalidColumnSpecification")

--- a/integration/projects/test_project_with_external_tables/test_project_with_external_tables.py
+++ b/integration/projects/test_project_with_external_tables/test_project_with_external_tables.py
@@ -1,0 +1,13 @@
+from dbt_dry_run.node_runner.snapshot_runner import DBT_SNAPSHOT_FIELDS
+from integration.conftest import IntegrationTestResult
+from integration.utils import get_report_node_by_id, assert_report_node_has_columns
+
+DBT_SNAPSHOT_COLUMN_NAMES = set([field.name for field in DBT_SNAPSHOT_FIELDS])
+
+
+def test_model_selecting_from_external_table_has_correct_schema(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "model.test_project_with_external_tables.first_layer")
+    assert node.success
+    assert_report_node_has_columns(node, {"rowkey", "events", "events.column", "events.column.name",
+                                          "events.column.cell", "events.column.cell.value"})

--- a/integration/utils.py
+++ b/integration/utils.py
@@ -31,7 +31,13 @@ def get_report_node_by_id(report: Report, unique_id: str) -> ReportNode:
 
 def assert_node_was_successful(report: Report, unique_id: str) -> None:
     node = get_report_node_by_id(report, unique_id)
-    assert node.success
+    assert node.success, f"Expected node f{node.unique_id} to be successful but it failed with error: {node.error_message}"
+
+
+def assert_node_failed_with_error(report: Report, unique_id: str, error: str) -> None:
+    node = get_report_node_by_id(report, unique_id)
+    assert not node.success, f"Expected node {node.unique_id} to fail but it was successful"
+    assert node.error_message == error, f"Node failed but error message '{node.error_message}' did not match expected: '{error}'"
 
 
 def assert_report_node_has_columns(node: ReportNode, columns: Set[str]) -> None:

--- a/integration/utils.py
+++ b/integration/utils.py
@@ -1,6 +1,7 @@
 from typing import Set
 
 from dbt_dry_run.models import Report, ReportNode
+from dbt_dry_run.columns_metadata import expand_table_fields
 from integration.conftest import IntegrationTestResult
 
 
@@ -34,5 +35,5 @@ def assert_node_was_successful(report: Report, unique_id: str) -> None:
 
 
 def assert_report_node_has_columns(node: ReportNode, columns: Set[str]) -> None:
-    column_names = set(map(lambda field: field.name, node.table.fields))
+    column_names = set(expand_table_fields(node.table))
     assert column_names == columns, f"Report node {node.unique_id} columns: {column_names} does not have expected columns: {columns}"


### PR DESCRIPTION
# Description

This PR adds support for dry running external sources when using the package [dbt-external-tables
](https://github.com/dbt-labs/dbt-external-tables). The dry runner will inspect the manifest `columns` definition for any source with an `external` attribute set and then use that as the dry run schema for downstream models.

Fixes #24

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
