### PR TITLE
Support INTERVAL and JSON types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+# dbt-dry-run v0.6.3
+
+## Bugfixes
+
+- Add support for INTERVAL and JSON types.
+
 # dbt-dry-run v0.6.2
 
 ## Bugfixes

--- a/dbt_dry_run/literals.py
+++ b/dbt_dry_run/literals.py
@@ -21,6 +21,7 @@ _EXAMPLE_VALUES: Dict[BigQueryFieldType, Callable[[], str]] = {
     BigQueryFieldType.TIME: lambda: "TIME(12,0,0)",
     BigQueryFieldType.DATETIME: lambda: "DATETIME(2021,1,1,12,0,0)",
     BigQueryFieldType.GEOGRAPHY: lambda: "ST_GeogPoint(0.0, 0.0)",
+    BigQueryFieldType.INTERVAL: lambda: "MAKE_INTERVAL(1)",
     BigQueryFieldType.NUMERIC: lambda: "CAST(1 AS NUMERIC)",
     BigQueryFieldType.BIGNUMERIC: lambda: "CAST(2 AS BIGNUMERIC)",
 }
@@ -38,6 +39,7 @@ _EXAMPLE_VALUES_TEST: Dict[BigQueryFieldType, Callable[[], str]] = {
     BigQueryFieldType.DATE: lambda: "DATE('2021-01-01')",
     BigQueryFieldType.TIME: lambda: "TIME(12,0,0)",
     BigQueryFieldType.DATETIME: lambda: "DATETIME(2021,1,1,12,0,0)",
+    BigQueryFieldType.INTERVAL: lambda: "MAKE_INTERVAL(1)",
     BigQueryFieldType.GEOGRAPHY: lambda: "ST_GeogPoint(0.0, 0.0)",
     BigQueryFieldType.NUMERIC: lambda: "CAST(1 AS NUMERIC)",
     BigQueryFieldType.BIGNUMERIC: lambda: "CAST(2 AS BIGNUMERIC)",

--- a/dbt_dry_run/literals.py
+++ b/dbt_dry_run/literals.py
@@ -24,6 +24,7 @@ _EXAMPLE_VALUES: Dict[BigQueryFieldType, Callable[[], str]] = {
     BigQueryFieldType.INTERVAL: lambda: "MAKE_INTERVAL(1)",
     BigQueryFieldType.NUMERIC: lambda: "CAST(1 AS NUMERIC)",
     BigQueryFieldType.BIGNUMERIC: lambda: "CAST(2 AS BIGNUMERIC)",
+    BigQueryFieldType.JSON: lambda: "PARSE_JSON('{\"a\": 1}')",
 }
 
 _EXAMPLE_VALUES_TEST: Dict[BigQueryFieldType, Callable[[], str]] = {
@@ -43,6 +44,7 @@ _EXAMPLE_VALUES_TEST: Dict[BigQueryFieldType, Callable[[], str]] = {
     BigQueryFieldType.GEOGRAPHY: lambda: "ST_GeogPoint(0.0, 0.0)",
     BigQueryFieldType.NUMERIC: lambda: "CAST(1 AS NUMERIC)",
     BigQueryFieldType.BIGNUMERIC: lambda: "CAST(2 AS BIGNUMERIC)",
+    BigQueryFieldType.JSON: lambda: "PARSE_JSON('{\"a\": 1}')",
 }
 
 _ACTIVE_EXAMPLE_VALUES = _EXAMPLE_VALUES

--- a/dbt_dry_run/models/table.py
+++ b/dbt_dry_run/models/table.py
@@ -26,6 +26,7 @@ class BigQueryFieldType(str, Enum):
     DATE = "DATE"
     TIME = "TIME"
     DATETIME = "DATETIME"
+    INTERVAL = "INTERVAL"
     GEOGRAPHY = "GEOGRAPHY"
     NUMERIC = "NUMERIC"
     BIGNUMERIC = "BIGNUMERIC"

--- a/dbt_dry_run/models/table.py
+++ b/dbt_dry_run/models/table.py
@@ -30,8 +30,9 @@ class BigQueryFieldType(str, Enum):
     GEOGRAPHY = "GEOGRAPHY"
     NUMERIC = "NUMERIC"
     BIGNUMERIC = "BIGNUMERIC"
-    RECORD = "RECORD"
     STRUCT = "STRUCT"
+    JSON = "JSON"
+    RECORD = "RECORD"
 
 
 class TableField(BaseModel):

--- a/dbt_dry_run/test/test_literals.py
+++ b/dbt_dry_run/test/test_literals.py
@@ -42,6 +42,11 @@ def test_single_field_integer_field() -> None:
     assert_fields_result_in_literal(fields, "(SELECT 1 as `foo`)")
 
 
+def test_single_field_interval_field() -> None:
+    fields = [TableField(name="foo", mode=BigQueryFieldMode.NULLABLE, type="INTERVAL")]
+    assert_fields_result_in_literal(fields, "(SELECT MAKE_INTERVAL(1) as `foo`)")
+
+
 def test_repeated_field() -> None:
     fields = [TableField(name="foo", mode=BigQueryFieldMode.REPEATED, type="STRING")]
     assert_fields_result_in_literal(fields, "(SELECT ['foo'] as `foo`)")

--- a/integration/projects/test_models_are_executed/models/model_with_all_column_types.sql
+++ b/integration/projects/test_models_are_executed/models/model_with_all_column_types.sql
@@ -39,6 +39,7 @@ simple_column_types AS (
         ST_GeogPoint(0.0, 0.0) AS my_geography,
         CAST(1 AS NUMERIC) AS my_numeric,
         CAST(2 AS BIGNUMERIC) AS my_bignumeric,
+        PARSE_JSON('{"a": 1}') AS my_json,
 ),
 all_column_types AS (
     SELECT * FROM simple_column_types
@@ -63,6 +64,7 @@ SELECT
     my_geography,
     my_numeric,
     my_bignumeric,
+    my_json,
     my_struct,
     my_array_of_records,
 FROM all_column_types

--- a/integration/projects/test_models_are_executed/models/model_with_all_column_types.sql
+++ b/integration/projects/test_models_are_executed/models/model_with_all_column_types.sql
@@ -1,0 +1,68 @@
+{{ config(alias="model_with_all_column_types") }}
+
+WITH
+generated_structure AS (
+    SELECT STRUCT(
+        "field-1" AS field_1,
+        2 AS field_2,
+        STRUCT(
+            "field-3-sub-field-1" AS field_3_sub_field_1,
+            "field-3-sub-field-2" AS field_3_sub_field_2
+        ) as field_3
+    ) AS my_struct
+),
+table_for_array_generation AS (
+    SELECT 1 AS aggregation_column, "row-1" AS col_1, 1 AS col_2
+    UNION ALL
+    SELECT 1 AS aggregation_column, "row-2" AS col_1, 2 AS col_2
+),
+generated_array AS (
+    SELECT aggregation_column, ARRAY_AGG(STRUCT(col_1, col_2)) AS my_array_of_records
+    FROM table_for_array_generation
+    GROUP BY aggregation_column
+),
+simple_column_types AS (
+    SELECT
+        'foo' AS my_string,
+        b'foo' AS my_bytes,
+        1 AS my_integer,
+        1 AS my_int64,
+        1.0 AS my_float,
+        1.0 AS my_float64,
+        true AS my_boolean,
+        true AS my_bool,
+        TIMESTAMP('2021-01-01') AS my_timestamp,
+        DATE('2021-01-01') AS my_date,
+        TIME(12,0,0) AS my_time,
+        DATETIME(2021,1,1,12,0,0) AS my_datetime,
+        MAKE_INTERVAL(1) AS my_interval,
+        ST_GeogPoint(0.0, 0.0) AS my_geography,
+        CAST(1 AS NUMERIC) AS my_numeric,
+        CAST(2 AS BIGNUMERIC) AS my_bignumeric,
+),
+all_column_types AS (
+    SELECT * FROM simple_column_types
+    LEFT OUTER JOIN generated_structure ON true
+    LEFT OUTER JOIN generated_array ON true
+)
+
+SELECT
+    my_string,
+    my_bytes,
+    my_integer,
+    my_int64,
+    my_float,
+    my_float64,
+    my_boolean,
+    my_bool,
+    my_timestamp,
+    my_date,
+    my_time,
+    my_datetime,
+    my_interval,
+    my_geography,
+    my_numeric,
+    my_bignumeric,
+    my_struct,
+    my_array_of_records,
+FROM all_column_types

--- a/integration/projects/test_models_are_executed/models/model_with_all_column_types.sql
+++ b/integration/projects/test_models_are_executed/models/model_with_all_column_types.sql
@@ -1,5 +1,3 @@
-{{ config(alias="model_with_all_column_types") }}
-
 WITH
 generated_structure AS (
     SELECT STRUCT(

--- a/integration/projects/test_models_are_executed/test_models_are_executed.py
+++ b/integration/projects/test_models_are_executed/test_models_are_executed.py
@@ -8,7 +8,7 @@ def test_success(dry_run_result: IntegrationTestResult):
 
 def test_ran_correct_number_of_nodes(dry_run_result: IntegrationTestResult):
     report = assert_report_success(dry_run_result)
-    assert report.node_count == 3
+    assert report.node_count == 4
 
 
 def test_table_of_nodes_is_returned(dry_run_result: IntegrationTestResult):

--- a/integration/projects/test_models_are_executed/test_models_are_executed.py
+++ b/integration/projects/test_models_are_executed/test_models_are_executed.py
@@ -27,3 +27,37 @@ def test_disabled_model_not_run(dry_run_result: IntegrationTestResult):
     report = assert_report_success(dry_run_result)
     assert "model.test_models_are_executed.disabled_model" not in set(
         n.unique_id for n in report.nodes), "Found disabled model in dry run output"
+
+
+def test_model_with_all_column_types_succeeds(dry_run_result: IntegrationTestResult):
+    node = get_report_node_by_id(dry_run_result.report,
+                                 "model.test_models_are_executed.model_with_all_column_types")
+    expected_column_names = {
+        "my_string",
+        "my_bytes",
+        "my_integer",
+        "my_int64",
+        "my_float",
+        "my_float64",
+        "my_boolean",
+        "my_bool",
+        "my_timestamp",
+        "my_date",
+        "my_time",
+        "my_datetime",
+        "my_interval",
+        "my_geography",
+        "my_numeric",
+        "my_bignumeric",
+        "my_json",
+        "my_struct",
+        "my_struct.field_1",
+        "my_struct.field_2",
+        "my_struct.field_3",
+        "my_struct.field_3.field_3_sub_field_1",
+        "my_struct.field_3.field_3_sub_field_2",
+        "my_array_of_records",
+        "my_array_of_records.col_1",
+        "my_array_of_records.col_2",
+    }
+    assert_report_node_has_columns(node, expected_column_names)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-dry-run"
-version = "0.6.3"
+version = "0.6.2"
 description = "Dry run dbt projects"
 authors = ["Connor Charles <connor.charles@autotrader.co.uk>",
            "Phil hope <philip.hope@autotrader.co.uk>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-dry-run"
-version = "0.6.2"
+version = "0.6.3"
 description = "Dry run dbt projects"
 authors = ["Connor Charles <connor.charles@autotrader.co.uk>",
            "Phil hope <philip.hope@autotrader.co.uk>",


### PR DESCRIPTION
# Description

`dbt-dry-run` failed a valid model that generated a field of `INTERVAL` type. @connor-charles asked me to add support for `JSON` type too. This PR adds support for both. If possible, I think it would be a good idea to keep the commits separate because the second (JSON) one shows what changes are required to add a new field type.

Fixes # (issue)

# Checklist:

- [y] I have run `make verify` and fixed any linting or test errors
- [y] I have added appropriate unit tests or if applicable an integration test
- [y] OPTIONAL: I have run `make integration` against a Big Query instance
