### PR TITLE
Add --skip-not-compiled flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+# dbt-dry-run v0.6.5
+
+## Bugfixes & Improvements
+
+- Added command line flag `--skip-not-compiled` which will override the default behaviour of raising a `NotCompiledExceptipon`
+  if a node is in the manifest that should be compiled. This should only be used in certain circumstances where you want 
+  to skip an entire section of your dbt project from the dry run. Or if you don't want to dry run tests
+  
+- Added `status` to the report artefact which can be `SUCCESS`, `FAILED`, `SKIPPED`
+
 # dbt-dry-run v0.6.4
 
 ## Bugfixes & Improvements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,27 @@
+# Contributing/Running locally
+
+To setup a dev environment you need [poetry][get-poetry], first run `poetry install` to install all dependencies. Then
+the `Makefile` contains all the commands needed to run the test suite and linting.
+
+- verify: Formats code with `black`, type checks with `mypy` and then runs the unit tests with coverage.
+- integration: Runs the integration tests against BigQuery (See Integration Tests)
+
+There is also a shell script `./run-integration.sh <PROJECT_DIR>` which will run one of the integration tests locally.
+Where `<PROJECT_DIR>` is one of the directory names in `/integration/projects/`. (See Integration Tests)
+
+## Running Integration Tests
+
+In order to run integration tests locally you will need access to a BigQuery project/instance in which your gcloud
+application default credentials has the role `Big Query Data Owner`. The BigQuery instance should have an empty dataset
+called `dry_run`.
+
+Setting the environment variable `DBT_PROJECT=<YOUR GCP PROJECT HERE>` will tell the integration tests which GCP project
+to run the test suite against. The test suite does not currently materialize any data into the project.
+
+The integration tests will run on any push to `main` to ensure the package's core functionality is still in place.
+
+__Auto Trader employees can request authorisation to access the `at-dry-run-integration-dev` project for this purpose__
+
 # Preparing for a Release
 
 ## Bump Version

--- a/dbt_dry_run/cli.py
+++ b/dbt_dry_run/cli.py
@@ -3,11 +3,12 @@ from typing import Optional
 
 import typer
 from dbt.flags import DEFAULT_PROFILES_DIR
-from typer import Argument, Option
+from typer import Option
 
 from dbt_dry_run.adapter.service import DbtArgs, ProjectService
 from dbt_dry_run.exception import ManifestValidationError
 from dbt_dry_run.execution import dry_run_manifest
+from dbt_dry_run.flags import Flags, set_flags
 from dbt_dry_run.result_reporter import ResultReporter
 
 app = typer.Typer()
@@ -20,7 +21,9 @@ def dry_run(
     verbose: bool = False,
     report_path: Optional[str] = None,
     cli_vars: str = "{}",
+    skip_not_compiled: bool = False,
 ) -> int:
+    set_flags(Flags(skip_not_compiled=skip_not_compiled))
     args = DbtArgs(
         project_dir=project_dir,
         profiles_dir=os.path.abspath(profiles_dir),
@@ -47,13 +50,15 @@ def dry_run(
     return exit_code
 
 
+_SKIP_NOT_COMPILED_HELP = """
+    Whether or not the dry run should ignore models that are not compiled. This has several caveats that make this 
+    not a recommended option. The dbt manifest should generally be compiled with `--select *` to ensure good 
+    coverage
+"""
+
+
 @app.command()
 def run(
-    profile: Optional[str] = Argument(
-        None,
-        hidden=True,
-        help="Legacy parameter. You should not use this anymore see CHANGES.md in the github repo for how to migrate",
-    ),
     profiles_dir: str = Option(
         DEFAULT_PROFILES_DIR, help="[dbt] Where to search for `profiles.yml`"
     ),
@@ -64,13 +69,13 @@ def run(
     target: Optional[str] = Option(None, help="[dbt] Target profile"),
     verbose: bool = Option(False, help="Output verbose error messages"),
     report_path: Optional[str] = Option(None, help="Json path to dump report to"),
+    skip_not_compiled: bool = Option(
+        False, "--skip-not-compiled", help=_SKIP_NOT_COMPILED_HELP
+    ),
 ) -> None:
-    if profile is not None:
-        print(
-            "CLI format has changed see CHANGES.md v0.4.0 for instructions on how to migrate"
-        )
-        raise typer.Exit(1)
-    exit_code = dry_run(project_dir, profiles_dir, target, verbose, report_path, vars)
+    exit_code = dry_run(
+        project_dir, profiles_dir, target, verbose, report_path, vars, skip_not_compiled
+    )
     if exit_code > 0:
         raise typer.Exit(exit_code)
 

--- a/dbt_dry_run/execution.py
+++ b/dbt_dry_run/execution.py
@@ -3,7 +3,6 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple
 
-from dbt_dry_run import flags
 from dbt_dry_run.adapter.service import ProjectService
 from dbt_dry_run.linting.column_linting import lint_columns
 from dbt_dry_run.sql_runner import SQLRunner
@@ -13,11 +12,7 @@ if TYPE_CHECKING:
 else:
     from typing import Awaitable as Future
 
-from dbt_dry_run.exception import (
-    ManifestValidationError,
-    NodeExecutionException,
-    NotCompiledException,
-)
+from dbt_dry_run.exception import ManifestValidationError, NodeExecutionException
 from dbt_dry_run.models.manifest import Manifest, Node
 from dbt_dry_run.node_runner import NodeRunner, get_runner_map
 from dbt_dry_run.node_runner.model_runner import ModelRunner
@@ -25,7 +20,7 @@ from dbt_dry_run.node_runner.node_test_runner import NodeTestRunner
 from dbt_dry_run.node_runner.seed_runner import SeedRunner
 from dbt_dry_run.node_runner.snapshot_runner import SnapshotRunner
 from dbt_dry_run.node_runner.source_runner import SourceRunner
-from dbt_dry_run.results import DryRunResult, DryRunStatus, Results
+from dbt_dry_run.results import DryRunResult, Results
 from dbt_dry_run.scheduler import ManifestScheduler
 from dbt_dry_run.sql_runner.big_query_sql_runner import BigQuerySQLRunner
 

--- a/dbt_dry_run/flags.py
+++ b/dbt_dry_run/flags.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+SKIP_NOT_COMPILED: bool = False
+
+
+@dataclass
+class Flags:
+    skip_not_compiled: bool = False
+
+
+_DEFAULT_FLAGS = Flags()
+
+
+def set_flags(flags: Flags) -> None:
+    global SKIP_NOT_COMPILED
+    SKIP_NOT_COMPILED = flags.skip_not_compiled
+
+
+def reset_flags() -> None:
+    set_flags(_DEFAULT_FLAGS)

--- a/dbt_dry_run/literals.py
+++ b/dbt_dry_run/literals.py
@@ -105,7 +105,10 @@ def insert_dependant_sql_literals(node: Node, results: Results) -> str:
         raise KeyError(f"deep_nodes have not been created for {node.unique_id}")
     failed_upstreams = [r for r in upstream_results if r.status != DryRunStatus.SUCCESS]
     if failed_upstreams:
-        msg = f"Can't insert SELECT literals for {node.unique_id} because {[f.node.unique_id for f in failed_upstreams]} failed"
+        failed_upstreams_messages = ", ".join(
+            [f"{f.node.unique_id} : {f.status}" for f in failed_upstreams]
+        )
+        msg = f"Can't insert SELECT literals for {node.unique_id}. Upstreams did not run with status: {failed_upstreams_messages}"
         raise UpstreamFailedException(msg)
     completed_upstreams = [r for r in upstream_results if r.table]
 

--- a/dbt_dry_run/models/report.py
+++ b/dbt_dry_run/models/report.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from pydantic import Field
 from pydantic.main import BaseModel
 
-from ..results import LintingStatus
+from ..results import DryRunStatus, LintingStatus
 from .table import Table
 
 
@@ -15,6 +15,7 @@ class ReportLintingError(BaseModel):
 class ReportNode(BaseModel):
     unique_id: str
     success: bool
+    status: DryRunStatus
     error_message: Optional[str]
     table: Optional[Table]
     linting_status: LintingStatus

--- a/dbt_dry_run/node_runner/__init__.py
+++ b/dbt_dry_run/node_runner/__init__.py
@@ -1,9 +1,11 @@
 import itertools
 from abc import ABCMeta, abstractmethod
-from typing import Dict, List, Tuple, Type
+from typing import Dict, List, Optional, Tuple, Type
 
+from dbt_dry_run import flags
+from dbt_dry_run.exception import NotCompiledException
 from dbt_dry_run.models.manifest import Node
-from dbt_dry_run.results import DryRunResult, Results
+from dbt_dry_run.results import DryRunResult, DryRunStatus, Results
 from dbt_dry_run.sql_runner import SQLRunner
 
 
@@ -21,6 +23,25 @@ class NodeRunner(metaclass=ABCMeta):
     @abstractmethod
     def run(self, node: Node) -> DryRunResult:
         ...
+
+    def validate_node(self, node: Node) -> Optional[DryRunResult]:
+        node_compiled = node.compiled
+        if not node_compiled:
+            if not flags.SKIP_NOT_COMPILED:
+                return DryRunResult(
+                    node=node,
+                    table=None,
+                    status=DryRunStatus.FAILURE,
+                    exception=NotCompiledException(
+                        f"Node {node.unique_id} was not compiled"
+                    ),
+                )
+            else:
+                return DryRunResult(
+                    node, table=None, status=DryRunStatus.SKIPPED, exception=None
+                )
+        else:
+            return None
 
 
 def _get_runner_resource_types(

--- a/dbt_dry_run/node_runner/seed_runner.py
+++ b/dbt_dry_run/node_runner/seed_runner.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import List, Optional
 
 import agate as ag
 from agate import data_types
@@ -39,3 +39,6 @@ class SeedRunner(NodeRunner):
         return DryRunResult(
             node=node, table=schema, status=DryRunStatus.SUCCESS, exception=None
         )
+
+    def validate_node(self, node: Node) -> Optional[DryRunResult]:
+        return None

--- a/dbt_dry_run/node_runner/source_runner.py
+++ b/dbt_dry_run/node_runner/source_runner.py
@@ -36,3 +36,6 @@ class SourceRunner(NodeRunner):
                 )
 
         return DryRunResult(node, predicted_table, status, exception)
+
+    def validate_node(self, node: Node) -> Optional[DryRunResult]:
+        return None

--- a/dbt_dry_run/result_reporter.py
+++ b/dbt_dry_run/result_reporter.py
@@ -60,6 +60,7 @@ class ResultReporter:
             new_node = ReportNode(
                 unique_id=result.node.unique_id,
                 success=result.status == DryRunStatus.SUCCESS,
+                status=result.status,
                 error_message=exception_type,
                 table=result.table,
                 linting_status=result.linting_status,

--- a/dbt_dry_run/results.py
+++ b/dbt_dry_run/results.py
@@ -11,6 +11,7 @@ from dbt_dry_run.models.table import Table
 class DryRunStatus(str, Enum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
+    SKIPPED = "SKIPPED"
 
 
 class LintingStatus(str, Enum):

--- a/dbt_dry_run/test/conftest.py
+++ b/dbt_dry_run/test/conftest.py
@@ -1,0 +1,12 @@
+from typing import Generator
+
+import pytest
+
+from dbt_dry_run import flags
+
+
+@pytest.fixture
+def default_flags() -> Generator[flags.Flags, None, None]:
+    flags.reset_flags()
+    yield flags._DEFAULT_FLAGS
+    flags.reset_flags()

--- a/dbt_dry_run/test/node_runner/test_model_runner.py
+++ b/dbt_dry_run/test/node_runner/test_model_runner.py
@@ -1,6 +1,12 @@
 from unittest.mock import MagicMock
 
-from dbt_dry_run.exception import SchemaChangeException, UpstreamFailedException
+from dbt_dry_run import flags
+from dbt_dry_run.exception import (
+    NotCompiledException,
+    SchemaChangeException,
+    UpstreamFailedException,
+)
+from dbt_dry_run.flags import Flags
 from dbt_dry_run.literals import enable_test_example_values
 from dbt_dry_run.models import BigQueryFieldType, Table, TableField
 from dbt_dry_run.models.manifest import NodeConfig, PartitionBy
@@ -460,3 +466,41 @@ def test_model_with_sql_header_executes_header_first() -> None:
     executed_sql = get_executed_sql(mock_sql_runner)
     assert executed_sql.startswith(pre_header_value)
     assert node.compiled_code in executed_sql
+
+
+def test_validate_node_fails_if_skip_not_compiled_is_false(
+    default_flags: Flags,
+) -> None:
+    flags.set_flags(flags.Flags(skip_not_compiled=False))
+    mock_sql_runner = MagicMock()
+    results = MagicMock()
+
+    node = SimpleNode(
+        unique_id="node1", depends_on=[], resource_type=ManifestScheduler.MODEL
+    ).to_node()
+    node.compiled = False
+
+    model_runner = ModelRunner(mock_sql_runner, results)
+
+    validation_result = model_runner.validate_node(node)
+    assert validation_result
+    assert validation_result.status == DryRunStatus.FAILURE
+    assert isinstance(validation_result.exception, NotCompiledException)
+
+
+def test_validate_node_skips_if_skip_not_compiled_is_true(default_flags: Flags) -> None:
+    flags.set_flags(flags.Flags(skip_not_compiled=True))
+    mock_sql_runner = MagicMock()
+    results = MagicMock()
+
+    node = SimpleNode(
+        unique_id="node1", depends_on=[], resource_type=ManifestScheduler.MODEL
+    ).to_node()
+    node.compiled = False
+
+    model_runner = ModelRunner(mock_sql_runner, results)
+
+    validation_result = model_runner.validate_node(node)
+    assert validation_result
+    assert validation_result.status == DryRunStatus.SKIPPED
+    assert validation_result.exception is None

--- a/dbt_dry_run/test/node_runner/test_node_runner.py
+++ b/dbt_dry_run/test/node_runner/test_node_runner.py
@@ -1,10 +1,8 @@
 from typing import cast
-from unittest.mock import MagicMock
 
 from dbt_dry_run.models import Node
 from dbt_dry_run.node_runner import NodeRunner, get_runner_map
-from dbt_dry_run.results import DryRunResult, Results
-from dbt_dry_run.sql_runner.big_query_sql_runner import BigQuerySQLRunner
+from dbt_dry_run.results import DryRunResult
 
 
 class SingleNodeRunner(NodeRunner):

--- a/dbt_dry_run/test/node_runner/test_seed_runner.py
+++ b/dbt_dry_run/test/node_runner/test_seed_runner.py
@@ -2,6 +2,9 @@ from pathlib import Path
 from typing import Set
 from unittest.mock import MagicMock
 
+from dbt_dry_run import flags
+from dbt_dry_run.exception import NotCompiledException
+from dbt_dry_run.flags import Flags
 from dbt_dry_run.models import BigQueryFieldType
 from dbt_dry_run.models.manifest import Node
 from dbt_dry_run.node_runner.seed_runner import SeedRunner
@@ -61,3 +64,18 @@ def test_seed_runner_infers_dates(tmp_path: Path) -> None:
 
     assert result.table
     assert result.table.fields[2].type_ == BigQueryFieldType.DATE
+
+
+def test_validate_node_returns_none_if_node_is_not_compiled() -> None:
+    mock_sql_runner = MagicMock()
+    results = MagicMock()
+
+    node = SimpleNode(
+        unique_id="node1", depends_on=[], resource_type=ManifestScheduler.MODEL
+    ).to_node()
+    node.compiled = False
+
+    model_runner = SeedRunner(mock_sql_runner, results)
+
+    validation_result = model_runner.validate_node(node)
+    assert validation_result is None

--- a/integration/projects/test_large_projects_complete_quickly/test_large_projects_complete_quickly.py
+++ b/integration/projects/test_large_projects_complete_quickly/test_large_projects_complete_quickly.py
@@ -1,7 +1,10 @@
+import pytest
+
 from integration.conftest import IntegrationTestResult
 from integration.utils import assert_report_success
 
 
+@pytest.mark.skip(reason="Flaky test. Only include if worried about performance")
 def test_success(dry_run_result: IntegrationTestResult):
     assert_report_success(dry_run_result)
 

--- a/integration/projects/test_partially_compiled_project/dbt_project.yml
+++ b/integration/projects/test_partially_compiled_project/dbt_project.yml
@@ -1,0 +1,27 @@
+name: 'test_partially_compiled_project'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+# This will get overridden by the root project
+profile: 'default'
+
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "logs"
+
+
+# Configuring models
+models:
+  # This should match your project name
+  test_partially_compiled_project:
+    +enabled: true
+    +materialized: view

--- a/integration/projects/test_partially_compiled_project/models/run_mart_model.sql
+++ b/integration/projects/test_partially_compiled_project/models/run_mart_model.sql
@@ -1,0 +1,6 @@
+{{
+    config(alias="run_mart_model")
+}}
+
+SELECT *
+FROM {{ ref("run_staging_model") }}

--- a/integration/projects/test_partially_compiled_project/models/run_staging_model.sql
+++ b/integration/projects/test_partially_compiled_project/models/run_staging_model.sql
@@ -1,0 +1,6 @@
+{{
+    config(alias="run_staging_model")
+}}
+
+SELECT *
+FROM (SELECT "a" as `a`, "b" as `b`, 1 as c)

--- a/integration/projects/test_partially_compiled_project/models/skip_mart_model.sql
+++ b/integration/projects/test_partially_compiled_project/models/skip_mart_model.sql
@@ -1,0 +1,6 @@
+{{
+    config(alias="skip_mart_model")
+}}
+
+SELECT *
+FROM {{ ref("skip_staging_model") }}

--- a/integration/projects/test_partially_compiled_project/models/skip_staging_model.sql
+++ b/integration/projects/test_partially_compiled_project/models/skip_staging_model.sql
@@ -1,0 +1,6 @@
+{{
+    config(alias="skip_staging_model")
+}}
+
+SELECT *
+FROM (SELECT "a" as `a`, "b" as `b`, 1 as c)

--- a/integration/projects/test_partially_compiled_project/selectors.yml
+++ b/integration/projects/test_partially_compiled_project/selectors.yml
@@ -1,0 +1,9 @@
+selectors:
+  - name: partial_compile
+    default: true
+    definition:
+      method: fqn
+      value: '*'
+      exclude:
+        - "skip_staging_model"
+        - "run_mart_model_excluded_test"

--- a/integration/projects/test_partially_compiled_project/test_partially_compiled_project.py
+++ b/integration/projects/test_partially_compiled_project/test_partially_compiled_project.py
@@ -1,0 +1,30 @@
+from dbt_dry_run.results import DryRunStatus
+from integration.conftest import IntegrationTestResult
+from integration.utils import assert_report_success, get_report_node_by_id, assert_report_node_has_columns
+
+
+def test_compiled_models_pass(dry_run_result_skip_not_compiled: IntegrationTestResult):
+    mart_node = get_report_node_by_id(dry_run_result_skip_not_compiled.report,
+                                      "model.test_partially_compiled_project.run_mart_model")
+
+    staging_node = get_report_node_by_id(dry_run_result_skip_not_compiled.report,
+                                         "model.test_partially_compiled_project.run_staging_model")
+    skipped_test_node = get_report_node_by_id(dry_run_result_skip_not_compiled.report,
+                                         "test.test_partially_compiled_project.run_mart_model_excluded_test")
+
+    assert mart_node.success
+    assert staging_node.success
+    assert skipped_test_node.status == DryRunStatus.SKIPPED
+
+
+def test_not_compiled_models_pass(dry_run_result_skip_not_compiled: IntegrationTestResult):
+    staging_node = get_report_node_by_id(dry_run_result_skip_not_compiled.report,
+                                         "model.test_partially_compiled_project.skip_staging_model")
+    mart_node = get_report_node_by_id(dry_run_result_skip_not_compiled.report,
+                                      "model.test_partially_compiled_project.skip_mart_model")
+    assert staging_node.status == DryRunStatus.SKIPPED
+    assert mart_node.status == DryRunStatus.FAILURE
+    assert mart_node.error_message == "UpstreamFailedException"
+
+# TODO: We want to assert that models downstream of `skip_staging_model` fail
+# TODO: Also want to add a case for a 'dangling' skipped model that shows it does not cause failure

--- a/integration/projects/test_partially_compiled_project/tests/run_mart_model_excluded_test.sql
+++ b/integration/projects/test_partially_compiled_project/tests/run_mart_model_excluded_test.sql
@@ -1,0 +1,2 @@
+SELECT *
+FROM {{ ref("run_mart_model") }}

--- a/integration/utils.py
+++ b/integration/utils.py
@@ -12,7 +12,7 @@ def assert_report_produced(result: IntegrationTestResult) -> Report:
 
 def assert_report_success(result: IntegrationTestResult) -> Report:
     assert result.report, f"Report is missing: {result.process.stdout}"
-    assert result.report.success
+    assert result.report.success, "Expected success but got failure"
     return result.report
 
 


### PR DESCRIPTION
# Description

Add `--skip-not-compiled` flag to dry runner to relax assertion that _all_ models must be compiled in the dbt project.

If the model is a `leaf` node (Has no downstream dependencies). You can now use `--skip-not-compiled` to override the default behaviour of raising a `NotCompiledException` if the dry run encounters a node that it should be able to dry run but it has been skipped when the manifest was compiled (Via a selector or `--exclude` parameter)

This is useful if you want to be able to not dry run tests (They are always leaf nodes) or if you want to skip an entire section of your dbt project, as long as the not compiled models have no downstream models that were compiled.

Fixes #31 

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
