### PR TITLE
Mark python 3.11 as supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/autotraderuk/dbt-dry-run"
 dbt-dry-run = "dbt_dry_run.__main__:main"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8,<3.12"
 agate = "^1.6"
 google-cloud-bigquery = "^3"
 pydantic = "^1.9.0"
@@ -46,7 +46,8 @@ filterwarnings = [
     "ignore:Deprecated call to",
     "ignore:pkg_resources is deprecated as an API",
     "ignore:invalid escape sequence",
-    "ignore:unclosed"
+    "ignore:unclosed",
+    "ignore:'cgi' is deprecated and slated for removal"
 ]
 pythonpath = [
   "."


### PR DESCRIPTION
# Description

Hey Charles! 

It seems that dbt-dry-run works fine in python 3.11 - I've ran both the integration tests and unit tests and they are all passing.

I did have to add an ignore for a deprecation warning for the [cgi module
](https://docs.python.org/3/library/cgi.html) which is due for removal in python 3.13. This is referred to by a transitive dependency (google-cloud-storage), hopefully they'll have sorted that by the time we have to worry about 3.13 🙂

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [ ] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
