### PR TITLE
Respect existing column ordering for incremental models

### DIFF
--- a/dbt_dry_run/columns_metadata.py
+++ b/dbt_dry_run/columns_metadata.py
@@ -1,5 +1,5 @@
 from itertools import groupby
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Tuple
 
 from dbt_dry_run.exception import InvalidColumnSpecification, UnknownDataTypeException
 from dbt_dry_run.models import BigQueryFieldMode, BigQueryFieldType, Table, TableField
@@ -22,7 +22,7 @@ def _extract_fields(
     return field_names
 
 
-def expand_table_fields(table: Table) -> Set[str]:
+def expand_table_fields(table: Table) -> List[str]:
     """
     Expand table fields to dot notation (like in dbt metadata)
 
@@ -30,7 +30,7 @@ def expand_table_fields(table: Table) -> Set[str]:
     Returns: ["a", "a.a1"]
     """
     name_type_pairs = _extract_fields(table.fields)
-    return set(name for name, _ in name_type_pairs)
+    return [name for name, _ in name_type_pairs]
 
 
 def expand_table_fields_with_types(table: Table) -> Dict[str, BigQueryFieldType]:

--- a/dbt_dry_run/node_runner/incremental_runner.py
+++ b/dbt_dry_run/node_runner/incremental_runner.py
@@ -51,9 +51,6 @@ def sync_all_columns_handler(
     return dry_run_result.replace_table(Table(fields=final_fields))
 
 
-
-
-
 def fail_handler(dry_run_result: DryRunResult, target_table: Table) -> DryRunResult:
     if dry_run_result.table is None:
         return dry_run_result

--- a/dbt_dry_run/test/test_columns_metadata.py
+++ b/dbt_dry_run/test/test_columns_metadata.py
@@ -36,7 +36,7 @@ def field_type_as_repeated(field_type: BigQueryFieldType) -> str:
 def test_expand_table_fields_with_column_names_with_no_nesting() -> None:
     table = Table(fields=[field_with_name("a"), field_with_name("b")])
 
-    expected = {"a", "b"}
+    expected = ["a", "b"]
     actual = expand_table_fields(table)
     assert actual == expected
 
@@ -52,7 +52,7 @@ def test_expand_table_fields_with_struct() -> None:
         ]
     )
 
-    expected = {"a", "struct", "struct.struct_1", "struct.struct_2"}
+    expected = ["a", "struct", "struct.struct_1", "struct.struct_2"]
     actual = expand_table_fields(table)
     assert actual == expected
 
@@ -70,7 +70,7 @@ def test_expand_table_fields_with_nested_struct() -> None:
         ]
     )
 
-    expected = {"a", "struct", "struct.struct_1", "struct.struct_1.struct_1_1"}
+    expected = ["a", "struct", "struct.struct_1", "struct.struct_1.struct_1_1"]
     actual = expand_table_fields(table)
     assert actual == expected
 

--- a/integration/projects/test_incremental/models/column_order_preserved_osc_append.sql
+++ b/integration/projects/test_incremental/models/column_order_preserved_osc_append.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        on_schema_change="append_new_columns"
+    )
+}}
+
+SELECT
+   col_1,
+   col_2
+FROM (SELECT "foo" as col_1, "bar" as col_2)

--- a/integration/projects/test_incremental/models/column_order_preserved_osc_ignore.sql
+++ b/integration/projects/test_incremental/models/column_order_preserved_osc_ignore.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        on_schema_change="ignore"
+    )
+}}
+
+SELECT
+   col_1,
+   col_2
+FROM (SELECT "foo" as col_1, "bar" as col_2)

--- a/integration/projects/test_incremental/test_incremental.py
+++ b/integration/projects/test_incremental/test_incremental.py
@@ -4,6 +4,7 @@ from integration.utils import (
     get_report_node_by_id,
     assert_node_failed_with_error,
     assert_report_produced,
+    assert_report_node_has_columns_in_order,
 )
 
 
@@ -125,3 +126,35 @@ def test_no_full_refresh_on_the_model_use_the_target_schema(
             node_id,
         )
         assert_report_node_has_columns(report_node, {"existing_column"})
+
+
+def test_column_order_preserved_on_schema_change_ignore(
+    compiled_project: ProjectContext,
+):
+    node_id = "model.test_incremental.column_order_preserved_osc_ignore"
+    manifest_node = compiled_project.manifest.nodes[node_id]
+    columns = ["col_2 STRING", "col_1 STRING"]
+    with compiled_project.create_state(manifest_node, columns):
+        run_result = compiled_project.dry_run()
+        assert_report_produced(run_result)
+        report_node = get_report_node_by_id(
+            run_result.report,
+            node_id,
+        )
+        assert_report_node_has_columns_in_order(report_node, ["col_2", "col_1"])
+
+
+def test_column_order_preserved_on_schema_change_append_new_columns(
+    compiled_project: ProjectContext,
+):
+    node_id = "model.test_incremental.column_order_preserved_osc_append"
+    manifest_node = compiled_project.manifest.nodes[node_id]
+    columns = ["col_2 STRING", "col_1 STRING"]
+    with compiled_project.create_state(manifest_node, columns):
+        run_result = compiled_project.dry_run()
+        assert_report_produced(run_result)
+        report_node = get_report_node_by_id(
+            run_result.report,
+            node_id,
+        )
+        assert_report_node_has_columns_in_order(report_node, ["col_2", "col_1"])

--- a/integration/utils.py
+++ b/integration/utils.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import Set, List
 
 from dbt_dry_run.models import Report, ReportNode
 from dbt_dry_run.columns_metadata import expand_table_fields
@@ -64,3 +64,12 @@ def assert_report_node_has_columns(node: ReportNode, columns: Set[str]) -> None:
     assert (
         column_names == columns
     ), f"Report node {node.unique_id} columns: {column_names} does not have expected columns: {columns}"
+
+
+def assert_report_node_has_columns_in_order(
+    node: ReportNode, columns: List[str]
+) -> None:
+    column_names = expand_table_fields(node.table)
+    assert (
+        column_names == columns
+    ), f"Report node {node.unique_id} columns: {column_names} does not have expected columns in order: {columns}"


### PR DESCRIPTION
# Description

This PR updates the `on_schema_change` handlers to respect the target environments column ordering

Fixes #48 

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
