### PR TITLE
Don't run merge if incremental has recursive CTES

### DIFF
--- a/integration/projects/test_incremental/models/recursive_cte.sql
+++ b/integration/projects/test_incremental/models/recursive_cte.sql
@@ -1,0 +1,15 @@
+{{
+    config(
+        materialized="incremental",
+        on_schema_change="ignore"
+    )
+}}
+
+WITH RECURSIVE my_cte AS (
+    SELECT "foo" as foo
+)
+
+SELECT
+   my_string
+FROM (SELECT "foo" as my_string, "bar" as foo)
+LEFT JOIN my_cte using(foo)

--- a/integration/projects/test_incremental/test_incremental.py
+++ b/integration/projects/test_incremental/test_incremental.py
@@ -144,6 +144,22 @@ def test_column_order_preserved_on_schema_change_ignore(
         assert_report_node_has_columns_in_order(report_node, ["col_2", "col_1"])
 
 
+def test_recursive_cte_does_not_check_merge_compatibility(
+    compiled_project: ProjectContext,
+):
+    node_id = "model.test_incremental.recursive_cte"
+    manifest_node = compiled_project.manifest.nodes[node_id]
+    columns = ["my_string NUMERIC"]
+    with compiled_project.create_state(manifest_node, columns):
+        run_result = compiled_project.dry_run()
+        assert_report_produced(run_result)
+        report_node = get_report_node_by_id(
+            run_result.report,
+            node_id,
+        )
+        assert_report_node_has_columns(report_node, {"my_string"})
+
+
 def test_column_order_preserved_on_schema_change_append_new_columns(
     compiled_project: ProjectContext,
 ):


### PR DESCRIPTION
# Description

Parses the node SQL to try to determine if `WITH RECURSIVE` is used anywhere. If it is then don't run the merge check as this is not supported for these models. This adds a possible false dry run success but it is an edge case.

Fixes #49

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
