### PR TITLE
fix: dbt-external-tables partitions

### DIFF
--- a/dbt_dry_run/models/manifest.py
+++ b/dbt_dry_run/models/manifest.py
@@ -81,10 +81,15 @@ class ManifestColumn(BaseModel):
 class ExternalConfig(BaseModel):
     location: str
     dry_run_columns: List[ManifestColumn] = Field(default_factory=lambda: list())
+    partitions: List[ManifestColumn] = Field(default_factory=lambda: list())
 
     @property
     def dry_run_columns_map(self) -> Dict[str, ManifestColumn]:
         return {c.name: c for c in self.dry_run_columns}
+
+    @property
+    def dry_run_partitions_map(self) -> Dict[str, ManifestColumn]:
+        return {c.name: c for c in self.partitions}
 
 
 class Node(BaseModel):

--- a/dbt_dry_run/models/manifest.py
+++ b/dbt_dry_run/models/manifest.py
@@ -88,7 +88,7 @@ class ExternalConfig(BaseModel):
         return {c.name: c for c in self.dry_run_columns}
 
     @property
-    def dry_run_partitions_map(self) -> Dict[str, ManifestColumn]:
+    def partitions_map(self) -> Dict[str, ManifestColumn]:
         return {c.name: c for c in self.partitions}
 
 

--- a/dbt_dry_run/node_runner/source_runner.py
+++ b/dbt_dry_run/node_runner/source_runner.py
@@ -24,7 +24,7 @@ class SourceRunner(NodeRunner):
                 columns_to_map = (
                     external_config.dry_run_columns_map
                     if external_config.dry_run_columns
-                    else {**external_config.dry_run_partitions_map, **node.columns}
+                    else {**external_config.partitions_map, **node.columns}
                 )
                 predicted_table = map_columns_to_table(columns_to_map)
             except (InvalidColumnSpecification, UnknownDataTypeException) as e:

--- a/dbt_dry_run/node_runner/source_runner.py
+++ b/dbt_dry_run/node_runner/source_runner.py
@@ -24,7 +24,7 @@ class SourceRunner(NodeRunner):
                 columns_to_map = (
                     external_config.dry_run_columns_map
                     if external_config.dry_run_columns
-                    else node.columns
+                    else {**external_config.dry_run_partitions_map, **node.columns}
                 )
                 predicted_table = map_columns_to_table(columns_to_map)
             except (InvalidColumnSpecification, UnknownDataTypeException) as e:


### PR DESCRIPTION
# Description

This update makes changes to how we handle partitions in our project. Here's what's new:

* We've added a partitions list in the ExternalConfig class. It's for keeping track of different sections of our data. By default, this list starts empty.
* There's now a quick way to see partition details in ExternalConfig through partitions_map
* We now consider partitions when we're organizing our data, making sure everything is in the right place.

Fixes #53

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [ ] I have added appropriate unit tests or if applicable an integration test
- [ ] OPTIONAL: I have run `make integration` against a Big Query instance
