### PR TITLE
Feat add total_bytes_processed to report

### DIFF
--- a/dbt_dry_run/models/report.py
+++ b/dbt_dry_run/models/report.py
@@ -18,6 +18,7 @@ class ReportNode(BaseModel):
     status: DryRunStatus
     error_message: Optional[str]
     table: Optional[Table]
+    total_bytes_processed: Optional[int]
     linting_status: LintingStatus
     linting_errors: List[ReportLintingError]
 

--- a/dbt_dry_run/node_runner/__init__.py
+++ b/dbt_dry_run/node_runner/__init__.py
@@ -30,13 +30,18 @@ class NodeRunner(metaclass=ABCMeta):
                     node=node,
                     table=None,
                     status=DryRunStatus.FAILURE,
+                    total_bytes_processed=0,
                     exception=NotCompiledException(
                         f"Node {node.unique_id} was not compiled"
                     ),
                 )
             else:
                 return DryRunResult(
-                    node, table=None, status=DryRunStatus.SKIPPED, exception=None
+                    node,
+                    table=None,
+                    status=DryRunStatus.SKIPPED,
+                    total_bytes_processed=0,
+                    exception=None,
                 )
         else:
             return None

--- a/dbt_dry_run/node_runner/node_test_runner.py
+++ b/dbt_dry_run/node_runner/node_test_runner.py
@@ -10,9 +10,16 @@ class NodeTestRunner(NodeRunner):
         try:
             run_sql = insert_dependant_sql_literals(node, self._results)
         except UpstreamFailedException as e:
-            return DryRunResult(node, None, DryRunStatus.FAILURE, e)
+            return DryRunResult(node, None, DryRunStatus.FAILURE, 0, e)
 
-        status, predicted_table, exception = self._sql_runner.query(run_sql)
+        (
+            status,
+            predicted_table,
+            total_bytes_processed,
+            exception,
+        ) = self._sql_runner.query(run_sql)
 
-        result = DryRunResult(node, predicted_table, status, exception)
+        result = DryRunResult(
+            node, predicted_table, status, total_bytes_processed, exception
+        )
         return result

--- a/dbt_dry_run/node_runner/seed_runner.py
+++ b/dbt_dry_run/node_runner/seed_runner.py
@@ -31,6 +31,7 @@ class SeedRunner(NodeRunner):
                     node=node,
                     table=None,
                     status=DryRunStatus.FAILURE,
+                    total_bytes_processed=0,
                     exception=exception,
                 )
             new_field = TableField(
@@ -40,7 +41,11 @@ class SeedRunner(NodeRunner):
 
         schema = Table(fields=fields)
         return DryRunResult(
-            node=node, table=schema, status=DryRunStatus.SUCCESS, exception=None
+            node=node,
+            table=schema,
+            status=DryRunStatus.SUCCESS,
+            total_bytes_processed=0,
+            exception=None,
         )
 
     def validate_node(self, node: Node) -> Optional[DryRunResult]:

--- a/dbt_dry_run/node_runner/source_runner.py
+++ b/dbt_dry_run/node_runner/source_runner.py
@@ -16,6 +16,7 @@ class SourceRunner(NodeRunner):
     def run(self, node: Node) -> DryRunResult:
         exception: Optional[Exception] = None
         predicted_table: Optional[Table] = None
+        total_bytes_processed: Optional[int] = 0
         status = DryRunStatus.SUCCESS
         if node.is_external_source():
             external_config = cast(ExternalConfig, node.external)
@@ -37,7 +38,9 @@ class SourceRunner(NodeRunner):
                     f"Could not find source in target environment for node '{node.unique_id}'"
                 )
 
-        return DryRunResult(node, predicted_table, status, exception)
+        return DryRunResult(
+            node, predicted_table, status, total_bytes_processed, exception
+        )
 
     def validate_node(self, node: Node) -> Optional[DryRunResult]:
         return None

--- a/dbt_dry_run/node_runner/table_runner.py
+++ b/dbt_dry_run/node_runner/table_runner.py
@@ -15,10 +15,14 @@ class TableRunner(NodeRunner):
         try:
             run_sql = insert_dependant_sql_literals(node, self._results)
         except UpstreamFailedException as e:
-            return DryRunResult(node, None, DryRunStatus.FAILURE, e)
+            return DryRunResult(node, None, DryRunStatus.FAILURE, 0, e)
 
         run_sql = self._modify_sql(node, run_sql)
-        status, model_schema, exception = self._sql_runner.query(run_sql)
+        status, model_schema, total_bytes_processed, exception = self._sql_runner.query(
+            run_sql
+        )
 
-        result = DryRunResult(node, model_schema, status, exception)
+        result = DryRunResult(
+            node, model_schema, status, total_bytes_processed, exception
+        )
         return result

--- a/dbt_dry_run/node_runner/view_runner.py
+++ b/dbt_dry_run/node_runner/view_runner.py
@@ -16,10 +16,14 @@ class ViewRunner(NodeRunner):
         try:
             run_sql = insert_dependant_sql_literals(node, self._results)
         except UpstreamFailedException as e:
-            return DryRunResult(node, None, DryRunStatus.FAILURE, e)
+            return DryRunResult(node, None, DryRunStatus.FAILURE, 0, e)
 
         run_sql = self._modify_sql(node, run_sql)
-        status, model_schema, exception = self._sql_runner.query(run_sql)
+        status, model_schema, total_bytes_processed, exception = self._sql_runner.query(
+            run_sql
+        )
 
-        result = DryRunResult(node, model_schema, status, exception)
+        result = DryRunResult(
+            node, model_schema, status, total_bytes_processed, exception
+        )
         return result

--- a/dbt_dry_run/result_reporter.py
+++ b/dbt_dry_run/result_reporter.py
@@ -63,6 +63,7 @@ class ResultReporter:
                 status=result.status,
                 error_message=exception_type,
                 table=result.table,
+                total_bytes_processed=result.total_bytes_processed,
                 linting_status=result.linting_status,
                 linting_errors=_map_column_errors(result.linting_errors),
             )

--- a/dbt_dry_run/results.py
+++ b/dbt_dry_run/results.py
@@ -31,13 +31,18 @@ class DryRunResult:
     node: Node
     table: Optional[Table]
     status: DryRunStatus
+    total_bytes_processed: Optional[int]
     exception: Optional[Exception]
     linting_status: LintingStatus = LintingStatus.SKIPPED
     linting_errors: List[LintingError] = field(default_factory=lambda: [])
 
     def replace_table(self, table: Table) -> "DryRunResult":
         return DryRunResult(
-            node=self.node, table=table, status=self.status, exception=self.exception
+            node=self.node,
+            table=table,
+            status=self.status,
+            total_bytes_processed=self.total_bytes_processed,
+            exception=self.exception,
         )
 
     def with_linting_errors(self, linting_errors: List[LintingError]) -> "DryRunResult":
@@ -49,6 +54,7 @@ class DryRunResult:
             node=self.node,
             table=self.table,
             status=self.status,
+            total_bytes_processed=self.total_bytes_processed,
             exception=self.exception,
             linting_errors=linting_errors,
             linting_status=linting_status,

--- a/dbt_dry_run/sql_runner/__init__.py
+++ b/dbt_dry_run/sql_runner/__init__.py
@@ -28,7 +28,7 @@ class SQLRunner(metaclass=ABCMeta):
     @abstractmethod
     def query(
         self, sql: str
-    ) -> Tuple[DryRunStatus, Optional[Table], Optional[Exception]]:
+    ) -> Tuple[DryRunStatus, Optional[Table], Optional[int], Optional[Exception]]:
         ...
 
     def convert_agate_type(

--- a/dbt_dry_run/test/node_runner/test_incremental_runner.py
+++ b/dbt_dry_run/test/node_runner/test_incremental_runner.py
@@ -30,6 +30,8 @@ A_SIMPLE_TABLE = Table(
     ]
 )
 
+A_TOTAL_BYTES_PROCESSED = 1000
+
 A_NODE = SimpleNode(
     unique_id="node1", depends_on=[], resource_type=ManifestScheduler.MODEL
 ).to_node()
@@ -58,7 +60,7 @@ def get_mock_sql_runner_with(
     model_schema: Table, target_schema: Optional[Table]
 ) -> MagicMock:
     mock_sql_runner = MagicMock()
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, model_schema, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, model_schema, 0, None)
     mock_sql_runner.get_node_schema.return_value = target_schema
     return mock_sql_runner
 
@@ -68,7 +70,12 @@ def test_partitioned_incremental_model_declares_dbt_max_partition_variable() -> 
         "declare _dbt_max_partition timestamp default CURRENT_TIMESTAMP();"
     )
     mock_sql_runner = MagicMock()
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, A_SIMPLE_TABLE, None)
+    mock_sql_runner.query.return_value = (
+        DryRunStatus.SUCCESS,
+        A_SIMPLE_TABLE,
+        A_TOTAL_BYTES_PROCESSED,
+        None,
+    )
 
     node = SimpleNode(
         unique_id="node1",
@@ -463,7 +470,12 @@ def test_node_with_false_full_refresh_does_not_full_refresh_when_flag_is_true(
 
 def test_model_with_sql_header_executes_header_first() -> None:
     mock_sql_runner = MagicMock()
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, A_SIMPLE_TABLE, None)
+    mock_sql_runner.query.return_value = (
+        DryRunStatus.SUCCESS,
+        A_SIMPLE_TABLE,
+        A_TOTAL_BYTES_PROCESSED,
+        None,
+    )
 
     pre_header_value = "DECLARE x INT64;"
 
@@ -492,7 +504,11 @@ def test_append_handler_preserves_existing_column_order() -> None:
         ]
     )
     dry_run_result = DryRunResult(
-        node=A_NODE, status=DryRunStatus.SUCCESS, table=model_table, exception=None
+        node=A_NODE,
+        status=DryRunStatus.SUCCESS,
+        table=model_table,
+        total_bytes_processed=0,
+        exception=None,
     )
     target_table = Table(
         fields=[
@@ -522,7 +538,11 @@ def test_sync_handler_preserves_existing_column_order() -> None:
         ]
     )
     dry_run_result = DryRunResult(
-        node=A_NODE, status=DryRunStatus.SUCCESS, table=model_table, exception=None
+        node=A_NODE,
+        status=DryRunStatus.SUCCESS,
+        table=model_table,
+        total_bytes_processed=0,
+        exception=None,
     )
     target_table = Table(
         fields=[

--- a/dbt_dry_run/test/node_runner/test_snapshot_runner.py
+++ b/dbt_dry_run/test/node_runner/test_snapshot_runner.py
@@ -41,7 +41,7 @@ def test_snapshot_with_check_all_strategy_runs_sql_with_id() -> None:
             )
         ]
     )
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, 0, None)
 
     node = SimpleNode(
         unique_id="node1",
@@ -76,7 +76,7 @@ def test_snapshot_with_check_all_strategy_fails_without_id() -> None:
             )
         ]
     )
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, 0, None)
 
     node = SimpleNode(
         unique_id="node1",
@@ -114,7 +114,7 @@ def test_snapshot_with_check_all_strategy_runs_sql_with_matching_columns() -> No
             ),
         ]
     )
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, 0, None)
 
     node = SimpleNode(
         unique_id="node1",
@@ -152,7 +152,7 @@ def test_snapshot_with_check_cols_strategy_fails_with_missing_column() -> None:
             )
         ]
     )
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, 0, None)
 
     node = SimpleNode(
         unique_id="node1",
@@ -187,7 +187,7 @@ def test_snapshot_with_timestamp_strategy_with_updated_at_column() -> None:
             TableField(name="last_updated_col", type=BigQueryFieldType.TIMESTAMP),
         ]
     )
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, 0, None)
 
     node = SimpleNode(
         unique_id="node1",
@@ -222,7 +222,7 @@ def test_snapshot_with_timestamp_strategy_with_missing_updated_at_column() -> No
             TableField(name="last_updated_col", type=BigQueryFieldType.TIMESTAMP),
         ]
     )
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, 0, None)
 
     node = SimpleNode(
         unique_id="node1",
@@ -261,7 +261,7 @@ def test_snapshot_with_list_of_unique_key_columns_raises_error() -> None:
             TableField(name="last_updated_col", type=BigQueryFieldType.TIMESTAMP),
         ]
     )
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, 0, None)
 
     node = SimpleNode(
         unique_id="node1",

--- a/dbt_dry_run/test/node_runner/test_test_runner.py
+++ b/dbt_dry_run/test/node_runner/test_test_runner.py
@@ -38,7 +38,7 @@ def test_test_runs_sql() -> None:
             )
         ]
     )
-    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, None)
+    mock_sql_runner.query.return_value = (DryRunStatus.SUCCESS, expected_table, 0, None)
 
     test_node = SimpleNode(
         unique_id="test1", depends_on=[], resource_type=ManifestScheduler.TEST

--- a/dbt_dry_run/test/sql_runner/test_big_query_sql_runner.py
+++ b/dbt_dry_run/test/sql_runner/test_big_query_sql_runner.py
@@ -56,7 +56,7 @@ def test_error_query_does_not_retry() -> None:
     sql_runner = BigQuerySQLRunner(cast(ProjectService, mock_project))
 
     expected_sql = "SELECT * FROM foo"
-    status, _, exc = sql_runner.query(expected_sql)
+    status, _, _, exc = sql_runner.query(expected_sql)
 
     assert status == DryRunStatus.FAILURE
     assert exc is raised_exception

--- a/dbt_dry_run/test/test_result_reporter.py
+++ b/dbt_dry_run/test/test_result_reporter.py
@@ -21,6 +21,7 @@ def successful_result() -> DryRunResult:
         table=Table(fields=[]),
         status=DryRunStatus.SUCCESS,
         exception=None,
+        total_bytes_processed=1000,
         linting_status=LintingStatus.SKIPPED,
     )
 
@@ -31,6 +32,7 @@ def failed_result() -> DryRunResult:
         node=SimpleNode(unique_id="B", depends_on=[]).to_node(),
         table=Table(fields=[]),
         status=DryRunStatus.FAILURE,
+        total_bytes_processed=0,
         exception=Exception("Oh no!"),
         linting_status=LintingStatus.SKIPPED,
     )
@@ -42,6 +44,7 @@ def failed_linting_result() -> DryRunResult:
         node=SimpleNode(unique_id="B", depends_on=[]).to_node(),
         table=Table(fields=[]),
         status=DryRunStatus.SUCCESS,
+        total_bytes_processed=1000,
         exception=None,
         linting_status=LintingStatus.FAILURE,
         linting_errors=[


### PR DESCRIPTION
# Description

Added total_bytes_processed to DryRunResult class and added support for total_bytes_processed in various runners.

Fixed: https://github.com/autotraderuk/dbt-dry-run/issues/58

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [ ] OPTIONAL: I have run `make integration` against a Big Query instance
