### PR TITLE
Fix,  dry run compiled code to get total_bytes_processed

### DIFF
--- a/dbt_dry_run/node_runner/node_test_runner.py
+++ b/dbt_dry_run/node_runner/node_test_runner.py
@@ -12,10 +12,12 @@ class NodeTestRunner(NodeRunner):
         except UpstreamFailedException as e:
             return DryRunResult(node, None, DryRunStatus.FAILURE, 0, e)
 
+        # Run the compiled code to get the total bytes processed
+        _, _, total_bytes_processed, _ = self._sql_runner.query(node.compiled_code)
         (
             status,
             predicted_table,
-            total_bytes_processed,
+            _,
             exception,
         ) = self._sql_runner.query(run_sql)
 

--- a/dbt_dry_run/node_runner/snapshot_runner.py
+++ b/dbt_dry_run/node_runner/snapshot_runner.py
@@ -93,10 +93,13 @@ class SnapshotRunner(NodeRunner):
         except UpstreamFailedException as e:
             return DryRunResult(node, None, DryRunStatus.FAILURE, 0, e)
 
+        # Run the compiled code to get the total bytes processed
+        _, _, total_bytes_processed, _ = self._sql_runner.query(node.compiled_code)
+
         (
             status,
             predicted_table,
-            total_bytes_processed,
+            _,
             exception,
         ) = self._sql_runner.query(run_sql)
         result = DryRunResult(

--- a/dbt_dry_run/node_runner/table_runner.py
+++ b/dbt_dry_run/node_runner/table_runner.py
@@ -17,10 +17,12 @@ class TableRunner(NodeRunner):
         except UpstreamFailedException as e:
             return DryRunResult(node, None, DryRunStatus.FAILURE, 0, e)
 
+        # Run the compiled code to get the total bytes processed
+        compiled_sql = self._modify_sql(node, node.compiled_code)
+        _, _, total_bytes_processed, _ = self._sql_runner.query(compiled_sql)
+
         run_sql = self._modify_sql(node, run_sql)
-        status, model_schema, total_bytes_processed, exception = self._sql_runner.query(
-            run_sql
-        )
+        status, model_schema, _, exception = self._sql_runner.query(run_sql)
 
         result = DryRunResult(
             node, model_schema, status, total_bytes_processed, exception

--- a/dbt_dry_run/node_runner/view_runner.py
+++ b/dbt_dry_run/node_runner/view_runner.py
@@ -18,10 +18,14 @@ class ViewRunner(NodeRunner):
         except UpstreamFailedException as e:
             return DryRunResult(node, None, DryRunStatus.FAILURE, 0, e)
 
+        # Run the compiled code to get the total bytes processed
+        compiled_sql = node.compiled_code
+        if node.config.sql_header:
+            compiled_sql = f"{node.config.sql_header}\n{compiled_sql}"
+        _, _, total_bytes_processed, _ = self._sql_runner.query(compiled_sql)
+
         run_sql = self._modify_sql(node, run_sql)
-        status, model_schema, total_bytes_processed, exception = self._sql_runner.query(
-            run_sql
-        )
+        status, model_schema, _, exception = self._sql_runner.query(run_sql)
 
         result = DryRunResult(
             node, model_schema, status, total_bytes_processed, exception

--- a/dbt_dry_run/test/node_runner/test_incremental_runner.py
+++ b/dbt_dry_run/test/node_runner/test_incremental_runner.py
@@ -101,7 +101,16 @@ def test_partitioned_incremental_model_declares_dbt_max_partition_variable() -> 
     model_runner = IncrementalRunner(mock_sql_runner, results)
     model_runner.run(node)
 
-    executed_sql = get_executed_sql(mock_sql_runner)
+    call_args = mock_sql_runner.query.call_args_list
+    assert len(call_args) == 2
+
+    executed_sql_for_total_bytes_processed = call_args[0].args[0]
+    assert executed_sql_for_total_bytes_processed.startswith(
+        dbt_max_partition_declaration
+    )
+    assert node.compiled_code in executed_sql_for_total_bytes_processed
+
+    executed_sql = call_args[1].args[0]
     assert executed_sql.startswith(dbt_max_partition_declaration)
     assert node.compiled_code in executed_sql
 
@@ -490,7 +499,14 @@ def test_model_with_sql_header_executes_header_first() -> None:
     model_runner = IncrementalRunner(mock_sql_runner, results)
     model_runner.run(node)
 
-    executed_sql = get_executed_sql(mock_sql_runner)
+    call_args = mock_sql_runner.query.call_args_list
+    assert len(call_args) == 2
+
+    executed_sql_for_total_bytes_processed = call_args[0].args[0]
+    assert executed_sql_for_total_bytes_processed.startswith(pre_header_value)
+    assert node.compiled_code in executed_sql_for_total_bytes_processed
+
+    executed_sql = call_args[1].args[0]
     assert executed_sql.startswith(pre_header_value)
     assert node.compiled_code in executed_sql
 

--- a/dbt_dry_run/test/node_runner/test_table_runner.py
+++ b/dbt_dry_run/test/node_runner/test_table_runner.py
@@ -133,7 +133,13 @@ def test_model_with_dependency_inserts_sql_literal() -> None:
     model_runner = TableRunner(mock_sql_runner, results)
     result = model_runner.run(node)
 
-    executed_sql = get_executed_sql(mock_sql_runner)
+    call_args = mock_sql_runner.query.call_args_list
+    assert len(call_args) == 2
+
+    executed_sql_for_total_bytes_processed = call_args[0].args[0]
+    assert executed_sql_for_total_bytes_processed == node.compiled_code
+
+    executed_sql = call_args[1].args[0]
     assert result.status == DryRunStatus.SUCCESS
     assert executed_sql == "SELECT * FROM (SELECT 'foo' as `a`)"
 
@@ -160,6 +166,13 @@ def test_model_with_sql_header_executes_header_first() -> None:
     model_runner = TableRunner(mock_sql_runner, results)
     model_runner.run(node)
 
-    executed_sql = get_executed_sql(mock_sql_runner)
+    call_args = mock_sql_runner.query.call_args_list
+    assert len(call_args) == 2
+
+    executed_sql_for_total_bytes_processed = call_args[0].args[0]
+    assert executed_sql_for_total_bytes_processed.startswith(pre_header_value)
+    assert node.compiled_code in executed_sql_for_total_bytes_processed
+
+    executed_sql = call_args[1].args[0]
     assert executed_sql.startswith(pre_header_value)
     assert node.compiled_code in executed_sql

--- a/dbt_dry_run/test/node_runner/test_view_runner.py
+++ b/dbt_dry_run/test/node_runner/test_view_runner.py
@@ -79,7 +79,13 @@ def test_model_as_view_runs_create_view() -> None:
     model_runner = ViewRunner(mock_sql_runner, results)
     model_runner.run(node)
 
-    executed_sql = get_executed_sql(mock_sql_runner)
+    call_args = mock_sql_runner.query.call_args_list
+    assert len(call_args) == 2
+
+    executed_sql_for_total_bytes_processed = call_args[0].args[0]
+    assert executed_sql_for_total_bytes_processed == node.compiled_code
+
+    executed_sql = call_args[1].args[0]
     assert executed_sql.startswith(VIEW_CREATION_SQL)
     assert node.compiled_code in executed_sql
 
@@ -161,7 +167,13 @@ def test_model_with_dependency_inserts_sql_literal() -> None:
     model_runner = ViewRunner(mock_sql_runner, results)
     result = model_runner.run(node)
 
-    executed_sql = get_executed_sql(mock_sql_runner)
+    call_args = mock_sql_runner.query.call_args_list
+    assert len(call_args) == 2
+
+    executed_sql_for_total_bytes_processed = call_args[0].args[0]
+    assert executed_sql_for_total_bytes_processed == node.compiled_code
+
+    executed_sql = call_args[1].args[0]
     assert result.status == DryRunStatus.SUCCESS
     assert result.total_bytes_processed == A_TOTAL_BYTES_PROCESSED
     assert executed_sql == sql_with_view_creation(
@@ -193,6 +205,13 @@ def test_model_with_sql_header_executes_header_first() -> None:
     model_runner = ViewRunner(mock_sql_runner, results)
     model_runner.run(node)
 
-    executed_sql = get_executed_sql(mock_sql_runner)
+    call_args = mock_sql_runner.query.call_args_list
+    assert len(call_args) == 2
+
+    executed_sql_for_total_bytes_processed = call_args[0].args[0]
+    assert executed_sql_for_total_bytes_processed.startswith(pre_header_value)
+    assert node.compiled_code in executed_sql_for_total_bytes_processed
+
+    executed_sql = call_args[1].args[0]
     assert executed_sql.startswith(pre_header_value)
     assert node.compiled_code in executed_sql


### PR DESCRIPTION
# Description

- Fixed #61 , #58 

PR in #61 to be able to report total_bytes_processed. But it was not the value I expected.

In the view runner, it is executed as a create view command, and in the another view (table, incremental node_test, snapshot), inject the sample values based on the referenced table, Therefore, the value of total_bytes_processed obtained was 0 or very small, regardless of the originally compiled sql.
It was not appropriate as a reference value.

- ref
  - https://github.com/autotraderuk/dbt-dry-run/blob/3d4fcfbb7e245b46246b4bc3f4b7312f53a3f4f3/dbt_dry_run/node_runner/view_runner.py#L16-L21
  - https://github.com/autotraderuk/dbt-dry-run/blob/3d4fcfbb7e245b46246b4bc3f4b7312f53a3f4f3/dbt_dry_run/node_runner/table_runner.py#L15-L20

So, added to dry run compiled code to get total_bytes_processed.

## Concerns

Because a dry-run is executed twice for a single view or table, there is a concern that the execution time may become longer if the size of the tables managed by dbt is large.

I tried it in my own environment and found that queries that use wildcard tables can take more than **a minute** to call once dry run api.   I do not want dbt-dry-run to run longer just to add total_bytes_processed  as reference values.

By using compiled sql that has not been replaced by literals, it is possible that the dry run may fail because it may refer to a table that does not exist in the production. (When dry run in compiled sql, exceptions are ignored, so total_bytes_processed will be null in that case.)

So, Is it better to add it as an optional feature? 

- https://cloud.google.com/bigquery/docs/querying-wildcard-tables

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [ ] OPTIONAL: I have run `make integration` against a Big Query instance
