### PR TITLE
fix: unrecognized _partitiontime for time ingestion partitioned models

### DIFF
--- a/dbt_dry_run/models/manifest.py
+++ b/dbt_dry_run/models/manifest.py
@@ -29,6 +29,7 @@ class PartitionBy(BaseModel):
     field: str
     data_type: Literal["timestamp", "date", "datetime", "int64"]
     range: Optional[IntPartitionRange]
+    time_ingestion_partitioning: Optional[bool]
 
     @root_validator(pre=True)
     def lower_data_type(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/integration/projects/test_incremental/models/partition_by_time_ingestion.sql
+++ b/integration/projects/test_incremental/models/partition_by_time_ingestion.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        materialized="incremental",
+        partition_by={
+            "field": "executed_at",
+            "data_type": "date",
+            "time_ingestion_partitioning": true
+        }
+    )
+}}
+
+SELECT
+    executed_at,
+    col_1,
+    col_2
+FROM (SELECT DATE('2024-06-06') as executed_at, "foo" as col_1, "bar" as col_2)

--- a/integration/projects/test_incremental/test_incremental.py
+++ b/integration/projects/test_incremental/test_incremental.py
@@ -210,3 +210,21 @@ def test_sql_header_and_max_partition(
         assert_report_node_has_columns_in_order(
             report_node, ["snapshot_date", "my_string", "my_func_output"]
         )
+
+
+def test_partition_by_time_ingestion(
+    compiled_project: ProjectContext,
+):
+    node_id = "model.test_incremental.partition_by_time_ingestion"
+    manifest_node = compiled_project.manifest.nodes[node_id]
+    columns = ["executed_at", "col_1 STRING", "col_2 STRING"]
+    with compiled_project.create_state(manifest_node, columns, "_PARTITIONTIME", False):
+        run_result = compiled_project.dry_run()
+        assert_report_produced(run_result)
+        report_node = get_report_node_by_id(
+            run_result.report,
+            node_id,
+        )
+        assert_report_node_has_columns_in_order(
+            report_node, ["executed_at", "col_1", "col_2", "_PARTITIONTIME"]
+        )


### PR DESCRIPTION
# Description

Update incremental runner to support models with time ingestion partitioning.

Fixes #73 

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
