### PR TITLE
Use view runner for materialized views

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+# dbt-dry-run v0.8.x
+
+## Bugfixes
+
+- Basic support for materialized views. This materialisation will be treated as a normal view. This means the dry run
+  may erroneously succeed if it contains SQL that is not supported for materialised views.
+
 # dbt-dry-run v0.8.3
 
 ## Bugfixes

--- a/dbt_dry_run/node_dispatch.py
+++ b/dbt_dry_run/node_dispatch.py
@@ -23,6 +23,7 @@ RUNNERS: Dict[RunnerKey, Type[NodeRunner]] = {
     RunnerKey("model", "incremental"): IncrementalRunner,
     RunnerKey("model", "table"): TableRunner,
     RunnerKey("model", "view"): ViewRunner,
+    RunnerKey("model", "materialized_view"): ViewRunner,
     RunnerKey("test", "test"): NodeTestRunner,
     RunnerKey("snapshot", "snapshot"): SnapshotRunner,
     RunnerKey("seed", "seed"): SeedRunner,

--- a/dbt_dry_run/scheduler.py
+++ b/dbt_dry_run/scheduler.py
@@ -13,7 +13,15 @@ class ManifestScheduler:
     SOURCE = "source"
     TEST = "test"
     RUNNABLE_RESOURCE_TYPE = (MODEL, SEED, SNAPSHOT, SOURCE, TEST)
-    RUNNABLE_MATERIAL = ("view", "table", "incremental", "seed", "snapshot", "test")
+    RUNNABLE_MATERIAL = (
+        "view",
+        "table",
+        "incremental",
+        "seed",
+        "snapshot",
+        "test",
+        "materialized_view",
+    )
 
     def __init__(self, manifest: Manifest, model: Optional[str] = None):
         self._manifest = manifest

--- a/integration/projects/test_models_are_executed/models/second_layer_materialized_view.sql
+++ b/integration/projects/test_models_are_executed/models/second_layer_materialized_view.sql
@@ -1,0 +1,8 @@
+{{
+config(
+    alias="second_layer_materialized_view",
+    materialized="materialized_view")
+}}
+
+SELECT *
+FROM {{ ref("first_layer") }}

--- a/integration/projects/test_models_are_executed/test_models_are_executed.py
+++ b/integration/projects/test_models_are_executed/test_models_are_executed.py
@@ -106,3 +106,13 @@ def test_incremental_that_references_model_passes(dry_run_result: DryRunResult):
 
     assert node.success
     assert_report_node_has_columns(node, {"a", "b", "c"})
+
+
+def test_materialized_view_schema_is_predicted(dry_run_result: DryRunResult):
+    node = get_report_node_by_id(
+        dry_run_result.report,
+        "model.test_models_are_executed.second_layer_materialized_view",
+    )
+
+    assert node.success
+    assert_report_node_has_columns(node, {"a", "b", "c"})


### PR DESCRIPTION
# Description

This change uses the view runner to also dry run materialized views.

Materialized views have quite a lot of limitations in BQ but you cannot change the DDL to `CREATE MATERIALIZED VIEW` because you get an error when pulling in the select literals saying that a materialized view must reference at least 1 real table. So we will have to use views for now. This will create false successes in the dry runner.

Fixes #88 

# Checklist:

- [x] I have run `make verify` and fixed any linting or test errors
- [x] I have added appropriate unit tests or if applicable an integration test
- [x] OPTIONAL: I have run `make integration` against a Big Query instance
