### PR TITLE
Fix, skip add partitiontime when node config partition field is partitiontime

### DIFF
--- a/dbt_dry_run/node_runner/incremental_runner.py
+++ b/dbt_dry_run/node_runner/incremental_runner.py
@@ -57,10 +57,13 @@ class IncrementalRunner(NodeRunner):
         if not dry_run_result.table:
             return dry_run_result
 
-        if (
-            not dry_run_result.node.config.partition_by
-            or dry_run_result.node.config.partition_by.field.lower() == "_partitiontime"
-        ):
+        if not dry_run_result.node.config.partition_by:
+            return dry_run_result
+
+        existing_field_names = {
+            field.name.upper() for field in dry_run_result.table.fields
+        }
+        if "_PARTITIONTIME" in existing_field_names:
             return dry_run_result
 
         new_partition_field = TableField(

--- a/dbt_dry_run/node_runner/incremental_runner.py
+++ b/dbt_dry_run/node_runner/incremental_runner.py
@@ -57,7 +57,10 @@ class IncrementalRunner(NodeRunner):
         if not dry_run_result.table:
             return dry_run_result
 
-        if not dry_run_result.node.config.partition_by:
+        if (
+            not dry_run_result.node.config.partition_by
+            or dry_run_result.node.config.partition_by.field.lower() == "_partitiontime"
+        ):
             return dry_run_result
 
         new_partition_field = TableField(

--- a/dbt_dry_run/sql/parsing.py
+++ b/dbt_dry_run/sql/parsing.py
@@ -12,10 +12,14 @@ def sql_has_recursive_ctes(code: str) -> bool:
     return False
 
 
+def get_quoted_field_names(field_names: Iterable[str]) -> Iterable[str]:
+    return [f"`{field_name}`" for field_name in field_names]
+
+
 def get_merge_sql(
     table_ref: TableRef, common_field_names: Iterable[str], select_statement: str
 ) -> str:
-    values_csv = ",".join(sorted(common_field_names))
+    values_csv = ",".join(sorted(get_quoted_field_names(common_field_names)))
     return dedent(
         f"""MERGE {table_ref.bq_literal}
                 USING (

--- a/dbt_dry_run/test/node_runner/test_incremental_runner.py
+++ b/dbt_dry_run/test/node_runner/test_incremental_runner.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, call, patch
 from dbt_dry_run import flags
 from dbt_dry_run.exception import SchemaChangeException
 from dbt_dry_run.models import BigQueryFieldType, Table, TableField
-from dbt_dry_run.models.dry_run_result import DryRunResult
 from dbt_dry_run.models.manifest import NodeConfig, PartitionBy
 from dbt_dry_run.models.report import DryRunStatus
 from dbt_dry_run.node_runner.incremental_runner import IncrementalRunner

--- a/dbt_dry_run/test/node_runner/test_incremental_runner.py
+++ b/dbt_dry_run/test/node_runner/test_incremental_runner.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call
 from dbt_dry_run import flags
 from dbt_dry_run.exception import SchemaChangeException
 from dbt_dry_run.models import BigQueryFieldType, Table, TableField
+from dbt_dry_run.models.dry_run_result import DryRunResult
 from dbt_dry_run.models.manifest import NodeConfig, PartitionBy
 from dbt_dry_run.models.report import DryRunStatus
 from dbt_dry_run.node_runner.incremental_runner import IncrementalRunner
@@ -91,6 +92,46 @@ def test_partitioned_incremental_model_declares_dbt_max_partition_variable() -> 
     executed_sql = get_executed_sql(mock_sql_runner)
     assert executed_sql.startswith(dbt_max_partition_declaration)
     assert node.compiled_code in executed_sql
+
+
+def test_partitioned_incremental_model_does_not_add_partitiontime_column_when_field_is_partitiontime() -> None:
+    mock_sql_runner = MagicMock()
+    node = SimpleNode(
+        unique_id="node1",
+        depends_on=[],
+        resource_type=ManifestScheduler.MODEL,
+        table_config=NodeConfig(
+            materialized="incremental",
+            partition_by=PartitionBy(
+                field="_PARTITIONTIME",
+                data_type="timestamp",
+                time_ingestion_partitioning=True,
+            ),
+        ),
+    ).to_node()
+    node.depends_on.deep_nodes = []
+
+    result = DryRunResult(
+        node=node,
+        table=Table(
+            fields=[
+                TableField(name="_PARTITIONTIME", type=BigQueryFieldType.TIMESTAMP),
+                TableField(name="a", type=BigQueryFieldType.STRING),
+            ]
+        ),
+        status=DryRunStatus.SUCCESS,
+        exception=None,
+    )
+
+    updated_result = IncrementalRunner(mock_sql_runner, Results())._replace_partition_with_time_ingestion_column(
+        result
+    )
+
+    assert updated_result.table is not None
+    assert set([field.name for field in updated_result.table.fields]) == {
+        "a",
+        "_PARTITIONTIME",
+    }
 
 
 def test_incremental_model_that_does_not_exist_returns_dry_run_schema() -> None:

--- a/dbt_dry_run/test/node_runner/test_incremental_runner.py
+++ b/dbt_dry_run/test/node_runner/test_incremental_runner.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 from dbt_dry_run import flags
 from dbt_dry_run.exception import SchemaChangeException
@@ -94,8 +94,17 @@ def test_partitioned_incremental_model_declares_dbt_max_partition_variable() -> 
     assert node.compiled_code in executed_sql
 
 
-def test_partitioned_incremental_model_does_not_add_partitiontime_column_when_field_is_partitiontime() -> None:
+def test_partitioned_incremental_model_does_not_add_partitiontime_column_when_field_already_exist() -> (
+    None
+):
     mock_sql_runner = MagicMock()
+    mock_sql_runner.query.return_value = (
+        DryRunStatus.SUCCESS,
+        Table(fields=[TableField(name="a", type=BigQueryFieldType.STRING)]),
+        None,
+    )
+    mock_sql_runner.get_node_schema.return_value = None
+
     node = SimpleNode(
         unique_id="node1",
         depends_on=[],
@@ -111,22 +120,15 @@ def test_partitioned_incremental_model_does_not_add_partitiontime_column_when_fi
     ).to_node()
     node.depends_on.deep_nodes = []
 
-    result = DryRunResult(
-        node=node,
-        table=Table(
-            fields=[
-                TableField(name="_PARTITIONTIME", type=BigQueryFieldType.TIMESTAMP),
-                TableField(name="a", type=BigQueryFieldType.STRING),
-            ]
-        ),
-        status=DryRunStatus.SUCCESS,
-        exception=None,
-    )
+    model_runner = IncrementalRunner(mock_sql_runner, Results())
+    with patch.object(
+        model_runner,
+        "_replace_partition_with_time_ingestion_column",
+        wraps=model_runner._replace_partition_with_time_ingestion_column,
+    ) as replace_partition_mock:
+        updated_result = model_runner.run(node)
 
-    updated_result = IncrementalRunner(mock_sql_runner, Results())._replace_partition_with_time_ingestion_column(
-        result
-    )
-
+    assert replace_partition_mock.called
     assert updated_result.table is not None
     assert set([field.name for field in updated_result.table.fields]) == {
         "a",

--- a/integration/projects/test_incremental/models/partition_by_partitiontime.sql
+++ b/integration/projects/test_incremental/models/partition_by_partitiontime.sql
@@ -13,4 +13,4 @@ SELECT
     _PARTITIONTIME,
     col_1,
     col_2
-FROM (SELECT TIMESTAMP('2024-06-06 00:00:00') as _PARTITIONTIME, "foo" as col_1, "bar" as col_2)
+FROM (SELECT TIMESTAMP('2024-06-06 00:00:00') AS _PARTITIONTIME, "foo" AS col_1, "bar" AS col_2)

--- a/integration/projects/test_incremental/models/partition_by_partitiontime.sql
+++ b/integration/projects/test_incremental/models/partition_by_partitiontime.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        materialized="incremental",
+        partition_by={
+            "field": "_PARTITIONTIME",
+            "data_type": "timestamp",
+            "time_ingestion_partitioning": true
+        }
+    )
+}}
+
+SELECT
+    _PARTITIONTIME,
+    col_1,
+    col_2
+FROM (SELECT TIMESTAMP('2024-06-06 00:00:00') as _PARTITIONTIME, "foo" as col_1, "bar" as col_2)

--- a/integration/projects/test_incremental/test_incremental.py
+++ b/integration/projects/test_incremental/test_incremental.py
@@ -292,3 +292,21 @@ def test_partition_by_time_ingestion(
         assert_report_node_has_columns_in_order(
             report_node, ["executed_at", "col_1", "col_2", "_PARTITIONTIME"]
         )
+
+
+def test_partition_by_partitiontime_does_not_add_partitiontime_column(
+    compiled_project: ProjectContext,
+) -> None:
+    node_id = "model.test_incremental.partition_by_partitiontime"
+    manifest_node = compiled_project.manifest.nodes[node_id]
+    columns = ["_PARTITIONTIME TIMESTAMP", "col_1 STRING", "col_2 STRING"]
+    with compiled_project.create_state(manifest_node, columns, "_PARTITIONTIME", False):
+        run_result = compiled_project.dry_run()
+        assert_report_produced(run_result)
+        report_node = get_report_node_by_id(
+            run_result.get_report(),
+            node_id,
+        )
+        assert_report_node_has_columns_in_order(
+            report_node, ["_PARTITIONTIME", "col_1", "col_2"]
+        )


### PR DESCRIPTION
# Description

Handle ambiguous column _PARTITIONTIME caused by duplicate column called by [_replace_partition_with_time_ingestion_column](https://github.com/autotraderuk/dbt-dry-run/blob/8cf97efecbd1892c5b5b9f69619e3de9fc9b92eb/dbt_dry_run/node_runner/incremental_runner.py#L54) in incremental runner.

Fixes https://github.com/autotraderuk/dbt-dry-run/issues/100
Additionally fixes merge statement in parsing.py when there are columns of model with reserved keyword in Bigquery by adding single backticks.
https://github.com/autotraderuk/dbt-dry-run/blob/8cf97efecbd1892c5b5b9f69619e3de9fc9b92eb/dbt_dry_run/sql/parsing.py#L26

# Checklist:

- [v] I have run `make verify` and fixed any linting or test errors
- [v] I have added appropriate unit tests or if applicable an integration test
- [v] OPTIONAL: I have run `make integration` against a Big Query instance
